### PR TITLE
gdeploy: use 'create' and 'update' commands

### DIFF
--- a/cmd/gdeploy/commands/backup/backup.go
+++ b/cmd/gdeploy/commands/backup/backup.go
@@ -51,7 +51,7 @@ var Command = cli.Command{
 			return err
 		}
 
-		clio.Info("creating backup of Granted Approvals dynamoDB table: %s", stackOutput.DynamoDBTable)
+		clio.Info("Creating backup of Granted Approvals dynamoDB table: %s", stackOutput.DynamoDBTable)
 		confirm := c.Bool("confirm")
 		if !confirm {
 			cp := &survey.Confirm{Message: "Do you wish to continue?", Default: true}
@@ -68,10 +68,10 @@ var Command = cli.Command{
 		if err != nil {
 			return err
 		}
-		clio.Success("successfully started a backup of Granted Approvals dynamoDB table: %s", stackOutput.DynamoDBTable)
-		clio.Info("backup details\n%s", deploy.BackupDetailsToString(backupOutput))
-		clio.Info("to view the status of this backup, run `gdeploy backup status --arn=%s`", aws.ToString(backupOutput.BackupArn))
-		clio.Info("to restore from this backup, run `gdeploy restore --arn=%s`", aws.ToString(backupOutput.BackupArn))
+		clio.Success("Successfully started a backup of Granted Approvals dynamoDB table: %s", stackOutput.DynamoDBTable)
+		clio.Info("Backup details\n%s", deploy.BackupDetailsToString(backupOutput))
+		clio.Info("To view the status of this backup, run `gdeploy backup status --arn=%s`", aws.ToString(backupOutput.BackupArn))
+		clio.Info("To restore from this backup, run `gdeploy restore --arn=%s`", aws.ToString(backupOutput.BackupArn))
 
 		return nil
 	},

--- a/cmd/gdeploy/commands/backup/status.go
+++ b/cmd/gdeploy/commands/backup/status.go
@@ -19,7 +19,7 @@ var BackupStatus = cli.Command{
 		if err != nil {
 			return err
 		}
-		clio.Info("backup details\n%s", deploy.BackupDetailsToString(backupOutput.BackupDetails))
+		clio.Info("Backup details\n%s", deploy.BackupDetailsToString(backupOutput.BackupDetails))
 		return nil
 	},
 }

--- a/cmd/gdeploy/commands/create.go
+++ b/cmd/gdeploy/commands/create.go
@@ -1,0 +1,52 @@
+package commands
+
+import (
+	"github.com/common-fate/granted-approvals/pkg/clio"
+	"github.com/common-fate/granted-approvals/pkg/deploy"
+	"github.com/urfave/cli/v2"
+)
+
+var CreateCommand = cli.Command{
+	Name:        "create",
+	Usage:       "Create a new Granted Approvals deployment by deploying CloudFormation",
+	Description: "Create a new Granted Approvals deployment based on a deployment configuration file (granted-deployment.yml by default). Deploys resources to AWS using CloudFormation.",
+	Flags: []cli.Flag{
+		&cli.BoolFlag{Name: "confirm", Usage: "if provided, will automatically deploy without asking for confirmation"},
+	},
+	Action: func(c *cli.Context) error {
+		ctx := c.Context
+
+		f := c.Path("file")
+
+		dc, err := deploy.LoadConfig(f)
+		if err != nil {
+			return err
+		}
+
+		clio.Info("Deploying Granted Approvals %s", dc.Deployment.Release)
+		clio.Info("Using CloudFormation template: %s", dc.CfnTemplateURL())
+		confirm := c.Bool("confirm")
+		err = dc.DeployCloudFormation(ctx, confirm)
+		if err != nil {
+			return err
+		}
+		o, err := dc.LoadOutput(ctx)
+
+		if err != nil {
+			return err
+		}
+		o.PrintTable()
+
+		clio.Success("Your Granted deployment has been created")
+		clio.Info(`Here are your next steps to get started:
+
+  1) create an admin user so you can log in: 'gdeploy user create --admin -u YOUR_EMAIL_ADDRESS'
+  2) add an Access Provider: 'gdeploy provider add'
+  3) visit the web dashboard: 'gdeploy dashboard open'
+
+Check out the next steps in our getting started guide for more information: https://docs.comonfate.io/granted-approvals/getting-started/deploying
+`)
+
+		return nil
+	},
+}

--- a/cmd/gdeploy/commands/create.go
+++ b/cmd/gdeploy/commands/create.go
@@ -24,7 +24,7 @@ var CreateCommand = cli.Command{
 		}
 
 		clio.Info("Deploying Granted Approvals %s", dc.Deployment.Release)
-		clio.Info("Using CloudFormation template: %s", dc.CfnTemplateURL())
+		clio.Info("Using template: %s", dc.CfnTemplateURL())
 		confirm := c.Bool("confirm")
 		err = dc.DeployCloudFormation(ctx, confirm)
 		if err != nil {

--- a/cmd/gdeploy/commands/groups/add.go
+++ b/cmd/gdeploy/commands/groups/add.go
@@ -56,7 +56,7 @@ var addCommand = cli.Command{
 			return err
 		}
 
-		clio.Success("added user %s to group '%s'", username, group)
+		clio.Success("Added user %s to group '%s'", username, group)
 
 		return nil
 	},

--- a/cmd/gdeploy/commands/init.go
+++ b/cmd/gdeploy/commands/init.go
@@ -40,7 +40,7 @@ var InitCommand = cli.Command{
 		}
 
 		clio.Success("wrote config to %s", f)
-		clio.Warn("Nothing has been deployed yet. To finish deploying Granted Approvals, run 'gdeploy deploy' to create the CloudFormation stack in AWS.")
+		clio.Warn("Nothing has been deployed yet. To finish deploying Granted Approvals, run 'gdeploy create' to create the CloudFormation stack in AWS.")
 		return nil
 	},
 }

--- a/cmd/gdeploy/commands/init.go
+++ b/cmd/gdeploy/commands/init.go
@@ -39,7 +39,7 @@ var InitCommand = cli.Command{
 			return err
 		}
 
-		clio.Success("wrote config to %s", f)
+		clio.Success("Wrote config to %s", f)
 		clio.Warn("Nothing has been deployed yet. To finish deploying Granted Approvals, run 'gdeploy create' to create the CloudFormation stack in AWS.")
 		return nil
 	},

--- a/cmd/gdeploy/commands/logs/get.go
+++ b/cmd/gdeploy/commands/logs/get.go
@@ -73,7 +73,7 @@ var getCommand = cli.Command{
 			}
 			wg.Add(1)
 			go func(lg, s, start, end string) {
-				clio.Info("starting to watch logs for %s, log group id: %s", s, lg)
+				clio.Info("Starting to watch logs for %s, log group id: %s", s, lg)
 				getEvents(GetEventsOpts{Group: logGroup, Start: start, End: end})
 				wg.Done()
 			}(logGroup, service, start, end)

--- a/cmd/gdeploy/commands/logs/watch.go
+++ b/cmd/gdeploy/commands/logs/watch.go
@@ -68,7 +68,7 @@ var watchCommand = cli.Command{
 			}
 			wg.Add(1)
 			go func(lg, s string) {
-				clio.Info("starting to watch logs for %s, log group id: %s", s, lg)
+				clio.Info("Starting to watch logs for %s, log group id: %s", s, lg)
 				watchEvents(lg)
 				wg.Done()
 			}(logGroup, service)

--- a/cmd/gdeploy/commands/notifications/slack/configure.go
+++ b/cmd/gdeploy/commands/notifications/slack/configure.go
@@ -69,7 +69,7 @@ var configureSlackCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		clio.Info("You will need to re-deploy using gdeploy deploy Granted Approvals to see any changes")
+		clio.Warn("Your changes won't be applied until you redeploy. Run 'gdeploy update' to apply the changes to your CloudFormation deployment.")
 		clio.Success("Successfully enabled Slack")
 
 		return nil

--- a/cmd/gdeploy/commands/notifications/slack/disable.go
+++ b/cmd/gdeploy/commands/notifications/slack/disable.go
@@ -28,8 +28,8 @@ var disableSlackCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		clio.Info("You will need to re-deploy using gdeploy deploy Granted Approvals to see any changes")
 		clio.Success("Successfully deleted slack secrets")
+		clio.Warn("Your changes won't be applied until you redeploy. Run 'gdeploy update' to apply the changes to your CloudFormation deployment.")
 		return nil
 	},
 }

--- a/cmd/gdeploy/commands/provider/add.go
+++ b/cmd/gdeploy/commands/provider/add.go
@@ -176,7 +176,7 @@ If you want to overwrite the parameter, take one of the following actions:
 			return err
 		}
 
-		clio.Info("wrote %s to AWS SSM parameter %s", v.Key(), ssmKey)
+		clio.Info("Wrote %s to AWS SSM parameter %s", v.Key(), ssmKey)
 	}
 
 	return nil

--- a/cmd/gdeploy/commands/provider/add.go
+++ b/cmd/gdeploy/commands/provider/add.go
@@ -97,7 +97,7 @@ var addCommand = cli.Command{
 		}
 
 		clio.Success("wrote config to %s", f)
-		clio.Warn("Your changes won't be applied until you redeploy. Run 'gdeploy deploy' to apply the changes to your deployment.")
+		clio.Warn("Your changes won't be applied until you redeploy. Run 'gdeploy update' to apply the changes to your CloudFormation deployment.")
 		return nil
 	},
 }

--- a/cmd/gdeploy/commands/restore/restore.go
+++ b/cmd/gdeploy/commands/restore/restore.go
@@ -45,7 +45,7 @@ var Command = cli.Command{
 			return err
 		}
 
-		clio.Info("restoring Granted Approvals backup: %s to table: %s", aws.ToString(bs.BackupDetails.BackupName), tableName)
+		clio.Info("Restoring Granted Approvals backup: %s to table: %s", aws.ToString(bs.BackupDetails.BackupName), tableName)
 		confirm := c.Bool("confirm")
 		if !confirm {
 			cp := &survey.Confirm{Message: "Do you wish to continue?", Default: true}
@@ -59,8 +59,8 @@ var Command = cli.Command{
 		if err != nil {
 			return err
 		}
-		clio.Success("successfully started restoration")
-		clio.Success("to check the status of a restoration run `gdeploy restore status --table-name=%s`", tableName)
+		clio.Success("Successfully started restoration")
+		clio.Success("To check the status of a restoration run `gdeploy restore status --table-name=%s`", tableName)
 
 		return nil
 	},

--- a/cmd/gdeploy/commands/sso/sso.go
+++ b/cmd/gdeploy/commands/sso/sso.go
@@ -67,8 +67,8 @@ var configureCommand = cli.Command{
 					if err != nil {
 						return err
 					}
-					clio.Info("You will need to re-deploy using gdeploy deploy Granted Approvals to see any changes")
 					clio.Info("Successfully updated SSO configuration")
+					clio.Warn("Your changes won't be applied until you redeploy. Run 'gdeploy update' to apply the changes to your CloudFormation deployment.")
 					return nil
 
 				}
@@ -214,11 +214,8 @@ var configureCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-
-		clio.Info("You will need to re-deploy using gdeploy deploy Granted Approvals to see any changes")
-
 		clio.Success("completed SSO setup")
-
+		clio.Warn("Your changes won't be applied until you redeploy. Run 'gdeploy update' to apply the changes to your CloudFormation deployment.")
 		return nil
 
 	},

--- a/cmd/gdeploy/commands/sso/sso.go
+++ b/cmd/gdeploy/commands/sso/sso.go
@@ -82,13 +82,9 @@ var configureCommand = cli.Command{
 			}
 		}
 
-		//run through parameters setup
-
-		//TODO: replace with live docs link
-		docs := "https://docs.commonfate.io/granted/introduction/"
-
 		switch ssoEnable {
 		case "Google":
+			docs := "https://docs.commonfate.io/granted-approvals/sso/google"
 			clio.Info("Find documentation for setting up Google Workspace in our setup docs: %s", docs)
 
 			var google deploy.Google
@@ -151,8 +147,8 @@ var configureCommand = cli.Command{
 			dc.Deployment.Parameters.SamlSSOMetadata = metadata
 
 		case "Okta":
-
-			clio.Info("find documentation for setting up Okta in our setup docs: %s", docs)
+			docs := "https://docs.commonfate.io/granted-approvals/sso/okta"
+			clio.Info("Find documentation for setting up Okta in our setup docs: %s", docs)
 
 			var okta deploy.Okta
 			if dc.Identity != nil && dc.Identity.Google != nil {

--- a/cmd/gdeploy/commands/update.go
+++ b/cmd/gdeploy/commands/update.go
@@ -24,7 +24,7 @@ var UpdateCommand = cli.Command{
 		}
 
 		clio.Info("Deploying Granted Approvals %s", dc.Deployment.Release)
-		clio.Info("Using CloudFormation template: %s", dc.CfnTemplateURL())
+		clio.Info("Using template: %s", dc.CfnTemplateURL())
 		confirm := c.Bool("confirm")
 		err = dc.DeployCloudFormation(ctx, confirm)
 		if err != nil {

--- a/cmd/gdeploy/commands/update.go
+++ b/cmd/gdeploy/commands/update.go
@@ -1,4 +1,4 @@
-package deploy
+package commands
 
 import (
 	"github.com/common-fate/granted-approvals/pkg/clio"
@@ -6,9 +6,10 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var Command = cli.Command{
-	Name:        "deploy",
-	Description: "Deploy Granted Approvals",
+var UpdateCommand = cli.Command{
+	Name:        "update",
+	Usage:       "Update a Granted Approvals deployment CloudFormation stack",
+	Description: "Update Granted Approvals deployment based on a deployment configuration file (granted-deployment.yml by default). Deploys resources to AWS using CloudFormation.",
 	Flags: []cli.Flag{
 		&cli.BoolFlag{Name: "confirm", Usage: "if provided, will automatically deploy without asking for confirmation"},
 	},
@@ -22,7 +23,8 @@ var Command = cli.Command{
 			return err
 		}
 
-		clio.Info("deploying Granted Approvals %s", dc.Deployment.Release)
+		clio.Info("Deploying Granted Approvals %s", dc.Deployment.Release)
+		clio.Info("Using CloudFormation template: %s", dc.CfnTemplateURL())
 		confirm := c.Bool("confirm")
 		err = dc.DeployCloudFormation(ctx, confirm)
 		if err != nil {

--- a/cmd/gdeploy/main.go
+++ b/cmd/gdeploy/main.go
@@ -6,7 +6,6 @@ import (
 	"github.com/common-fate/granted-approvals/cmd/gdeploy/commands"
 	"github.com/common-fate/granted-approvals/cmd/gdeploy/commands/backup"
 	"github.com/common-fate/granted-approvals/cmd/gdeploy/commands/dashboard"
-	"github.com/common-fate/granted-approvals/cmd/gdeploy/commands/deploy"
 	"github.com/common-fate/granted-approvals/cmd/gdeploy/commands/groups"
 	"github.com/common-fate/granted-approvals/cmd/gdeploy/commands/logs"
 	"github.com/common-fate/granted-approvals/cmd/gdeploy/commands/notifications"
@@ -16,6 +15,7 @@ import (
 	"github.com/common-fate/granted-approvals/cmd/gdeploy/commands/sync"
 	"github.com/common-fate/granted-approvals/cmd/gdeploy/commands/users"
 	"github.com/common-fate/granted-approvals/internal/build"
+	"github.com/common-fate/granted-approvals/pkg/clio"
 	"github.com/fatih/color"
 	"github.com/mattn/go-colorable"
 	"github.com/urfave/cli/v2"
@@ -40,7 +40,8 @@ func main() {
 			&sync.SyncCommand,
 			&commands.StatusCommand,
 			&commands.InitCommand,
-			&deploy.Command,
+			&commands.CreateCommand,
+			&commands.UpdateCommand,
 			&sso.SSOCommand,
 			&backup.Command,
 			&restore.Command,
@@ -63,7 +64,7 @@ func main() {
 
 	err := app.Run(os.Args)
 	if err != nil {
-		log.Sugar().Error(err.Error())
+		clio.Error("%s", err.Error())
 		os.Exit(1)
 	}
 }

--- a/pkg/api/request_test.go
+++ b/pkg/api/request_test.go
@@ -406,7 +406,7 @@ func TestUserListRequests(t *testing.T) {
 			wantCode:     http.StatusBadRequest,
 			giveReviewer: &badReviewer,
 
-			wantBody: `{"error":"parameter \"reviewer\" in query has an error: value hello: an invalid number: strconv.ParseBool: parsing \"hello\": invalid syntax"}`,
+			wantBody: `{"error":"parameter \"reviewer\" in query has an error: value hello: an invalid boolean: invalid syntax"}`,
 		},
 		{
 			name:         "bad status",

--- a/pkg/deploy/output.go
+++ b/pkg/deploy/output.go
@@ -112,7 +112,7 @@ func (c *Config) LoadSAMLOutput(ctx context.Context) (SAMLOutputs, error) {
 
 To fix this, take one of the following actions:
   a) verify that your AWS credentials match the account you're trying to deploy to (%s). You can check this by calling 'aws sts get-caller-identity'.
-  b) your stack may not have been deployed yet. Run 'gdeploy deploy' to deploy it using CloudFormation.
+  b) your stack may not have been deployed yet. Run 'gdeploy create' to deploy it using CloudFormation.
 `, c.Deployment.StackName, c.Deployment.Region, c.Deployment.Account)
 		return SAMLOutputs{}, err
 	}
@@ -162,7 +162,7 @@ func (c *Config) LoadOutput(ctx context.Context) (Output, error) {
 
 To fix this, take one of the following actions:
   a) verify that your AWS credentials match the account you're trying to deploy to (%s). You can check this by calling 'aws sts get-caller-identity'.
-  b) your stack may not have been deployed yet. Run 'gdeploy deploy' to deploy it using CloudFormation.
+  b) your stack may not have been deployed yet. Run 'gdeploy create' to deploy it using CloudFormation.
 `, c.Deployment.StackName, c.Deployment.Region, c.Deployment.Account)
 		return Output{}, err
 	}


### PR DESCRIPTION
Previously our deployment command was 

```
gdeploy deploy
```

which encompassed both stack creation and stack updates.

This PR splits these into `gdeploy create` for creation, and `gdeploy update` for updates. Both of these commands currently do the same thing as `gdeploy deploy`. i.e. you can run `gdeploy create` and it works the same as `gdeploy deploy` used to, and will update an existing stack. In future we can add validation to avoid creating a stack 

The benefit here is that users should know if they already have a deployment or not, so if they run `gdeploy update` it's because they expect a stack to already exist. Rather than provisioning a new stack (which is likely not what a user will want) we can return an error message, as the user might be logged in to the wrong account or have their deployment config misconfigured.

For internal testing we can add `gdeploy update --create-if-not-exist` in future which will be useful for our CI/CD pipelines.

Also adds consistent capitalisation to usage of `clio` logging methods and fixes the docs link.