### PR TITLE
Add process for release candidate releasing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,8 +118,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-region: us-east-1
+          aws-region: us-west-2
           role-to-assume: "${{ secrets.AWS_TESTING_ROLE_ARN }}"
 
       - name: Release CloudFormation
-        run: go run mage.go -v release:production granted-test-releases-us-east-1 dev/${{ github.sha }}
+        run: go run mage.go -v release:production granted-test-releases-west-2 dev/${{ github.sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,5 +121,5 @@ jobs:
           aws-region: ap-southeast-2
           role-to-assume: "${{ secrets.AWS_TESTING_ROLE_ARN }}"
 
-      - name: Release Production Assets
+      - name: Release CloudFormation
         run: go run mage.go -v release:production granted-test-releases-us-east-1 dev/${{ github.sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,4 +122,4 @@ jobs:
           role-to-assume: "${{ secrets.AWS_TESTING_ROLE_ARN }}"
 
       - name: Release CloudFormation
-        run: go run mage.go -v release:production granted-test-releases-west-2 dev/${{ github.sha }}
+        run: go run mage.go -v release:production granted-test-releases-us-west-2 dev/${{ github.sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-region: ap-southeast-2
+          aws-region: us-east-1
           role-to-assume: "${{ secrets.AWS_TESTING_ROLE_ARN }}"
 
       - name: Release CloudFormation

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,4 +122,4 @@ jobs:
           role-to-assume: "${{ secrets.AWS_TESTING_ROLE_ARN }}"
 
       - name: Release Production Assets
-        run: go run mage.go -v release:production granted-internal-testing-releases ${{ github.sha }}
+        run: go run mage.go -v release:production granted-test-releases-us-east-1 dev/${{ github.sha }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-region: ap-southeast-2
+          aws-region: us-east-1
           role-to-assume: "${{ secrets.AWS_TESTING_ROLE_ARN }}"
 
       - name: Release CloudFormation

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -40,11 +40,11 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-region: us-east-1
+          aws-region: us-west-2
           role-to-assume: "${{ secrets.AWS_TESTING_ROLE_ARN }}"
 
       - name: Release CloudFormation
-        run: go run mage.go -v release:production granted-test-releases-us-east-1 dev/${{ github.sha }}
+        run: go run mage.go -v release:production granted-test-releases-us-west-2 dev/${{ github.sha }}
 
   deploy:
     name: Deploy

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -43,8 +43,8 @@ jobs:
           aws-region: ap-southeast-2
           role-to-assume: "${{ secrets.AWS_TESTING_ROLE_ARN }}"
 
-      - name: Release Production Assets
-        run: go run mage.go -v release:production granted-internal-testing-releases ${{ github.sha }}
+      - name: Release CloudFormation
+        run: go run mage.go -v release:production granted-test-releases-us-east-1 dev/${{ github.sha }}
 
   deploy:
     name: Deploy

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-region: ap-southeast-2
+          aws-region: us-east-1
           role-to-assume: "${{ secrets.AWS_TESTING_ROLE_ARN }}"
 
       - name: Release CloudFormation

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -42,9 +42,9 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-region: us-east-1
+          aws-region: us-west-2
           role-to-assume: "${{ secrets.AWS_TESTING_ROLE_ARN }}"
 
       - name: Release CloudFormation
         # github.ref_name gives the tag name, e.g. v0.1.0-rc1
-        run: go run mage.go -v release:production granted-test-releases-us-east-1 rc/${{ github.ref_name }}
+        run: go run mage.go -v release:production granted-test-releases-us-west-2 rc/${{ github.ref_name }}

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -1,0 +1,50 @@
+name: Release Candidate
+
+on:
+  push:
+    tags:
+      - "**-rc*"
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-20.04
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 7.1.5
+
+      - name: Setup NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: "pnpm"
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.17.8"
+          cache: true
+
+      - name: Install NodeJS dependencies
+        run: pnpm install
+
+      - name: Create empty aws-exports.js
+        run: echo 'export default {};' > ./web/src/utils/aws-exports.js
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: ap-southeast-2
+          role-to-assume: "${{ secrets.AWS_TESTING_ROLE_ARN }}"
+
+      - name: Release CloudFormation
+        # github.ref_name gives the tag name, e.g. v0.1.0-rc1
+        run: go run mage.go -v release:production granted-test-releases-us-east-1 rc/${{ github.ref_name }}

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,15 @@
+# Granted Approvals releases
+
+Our versioning follows [SemVer numbering](https://semver.org/). Currently both `gdeploy` and our CloudFormation templates are versioned and released together. In future, this may change if it's more convenient to use separate release cycles for each one.
+
+Prior to a release being made, we create a 'Release Candidate' (RC) version. The tagging format of an RC is `<NEXT_VERSION>-rc<RC_NUMBER>`, where `NEXT_VERSION` is the version we are planning to release (e.g. `v0.2.0`) and `RC_NUMBER` is a number starting at 1 which is incremented for each subsequent RC.
+
+An example of an RC tag is `v0.2.0-rc2`.
+
+The RC is released to the `granted-test-releases-us-east-1` S3 bucket. The CloudFormation template can be found at:
+
+```
+s3://granted-test-releases-us-east-1/rc/<TAG>/Granted.template.json
+```
+
+Where `<TAG>` is the RC tag, e.g. `v0.2.0-rc2`.

--- a/pkg/deploy/config_test.go
+++ b/pkg/deploy/config_test.go
@@ -122,3 +122,52 @@ func TestUnmarshalIdentity(t *testing.T) {
 		})
 	}
 }
+
+func TestCfnTemplateURL(t *testing.T) {
+	type testcase struct {
+		name string
+		give Config
+		want string
+	}
+
+	testcases := []testcase{
+		{
+			name: "version tag",
+			give: Config{
+				Deployment: Deployment{
+					Region:  "ap-southeast-2",
+					Release: "v0.1.0",
+				},
+			},
+			want: "https://granted-releases-ap-southeast-2.s3.amazonaws.com/v0.1.0/Granted.template.json",
+		},
+		{
+			name: "custom URL",
+			give: Config{
+				Deployment: Deployment{
+					Region:  "ap-southeast-2",
+					Release: "https://custom-release.s3.amazonaws.com/template.json",
+				},
+			},
+			want: "https://custom-release.s3.amazonaws.com/template.json",
+		},
+		{
+			// note: this currently won't return an error, even though CloudFormation will refuse to deploy it.
+			// this test captures this behaviour - in future we can add more validation around the URL.
+			name: "custom URL not in S3",
+			give: Config{
+				Deployment: Deployment{
+					Release: "https://some-other-url.com",
+				},
+			},
+			want: "https://some-other-url.com",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.give.CfnTemplateURL()
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
new bucket `granted-test-releases-us-east-1` is public which simplifies RC deployment testing

separate 'dev' and 'rc' folders:
- dev folder is for each commit
- rc folder is for RCs only

This also swaps the release bucket region from `ap-southeast-2` to `us-east-1` - the only motivation to use `us-east-1` is that we have our testing Cognito user pool there and that it's the same region as GitHub Actions runs in which should minimise latency. In future we can add other region buckets like `granted-test-releases-ap-southeast-2`.

Additionally, this PR adds support for using custom URLs in the `release` field in our deployment YAML config. This will allow us to point a deployment at a release candidate.

```yaml
deployment:
  stackName: ExampleStack
  account: "123456789012"
  region: us-east-1
  release: https://granted-test-releases-us-east-1.s3.amazonaws.com/rc/v0.1.1-rc1
```

We can use this to ensure that it's possible to upgrade from an existing release to the next RC, as some operations in CloudFormation can cause errors during stack updates (such as adding multiple GSIs at once)