### PR TITLE
Add json defaults for slack and access handler

### DIFF
--- a/accesshandler/pkg/config/providers.go
+++ b/accesshandler/pkg/config/providers.go
@@ -33,7 +33,7 @@ func ReadProviderConfig(ctx context.Context, runtime string) ([]byte, error) {
 	if !ok {
 		return nil, errors.New("PROVIDER_CONFIG environment variable not set")
 	}
-	// ensure that if the env var is set but is an epty string, that we replace it defensively with an empty json object to prevent 500 errors
+	// ensure that if the env var is set but is an empty string, we replace it defensively with an empty json object to prevent 500 errors
 	if providerCfg == "" {
 		providerCfg = "{}"
 	}

--- a/accesshandler/pkg/config/providers.go
+++ b/accesshandler/pkg/config/providers.go
@@ -33,6 +33,10 @@ func ReadProviderConfig(ctx context.Context, runtime string) ([]byte, error) {
 	if !ok {
 		return nil, errors.New("PROVIDER_CONFIG environment variable not set")
 	}
+	// ensure that if the env var is set but is an epty string, that we replace it defensively with an empty json object to prevent 500 errors
+	if providerCfg == "" {
+		providerCfg = "{}"
+	}
 	return []byte(providerCfg), nil
 }
 

--- a/cmd/gdeploy/commands/notifications/slack/configure.go
+++ b/cmd/gdeploy/commands/notifications/slack/configure.go
@@ -57,8 +57,8 @@ var configureSlackCommand = cli.Command{
 			return errors.Wrap(err, "failed while setting Slack parameters in ssm")
 		}
 
-		dc.Notifications = &deploy.Notifications{
-			Slack: &deploy.Slack{
+		dc.Notifications = &deploy.NotificationsConfig{
+			Slack: &deploy.SlackConfig{
 				APIToken: config.AWSSSMParamToken(suffixedPath, version),
 			},
 		}

--- a/cmd/lambda/event-handlers/notifiers/slack/handler.go
+++ b/cmd/lambda/event-handlers/notifiers/slack/handler.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/aws/aws-lambda-go/lambda"
 
@@ -34,8 +33,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	var s deploy.Slack
-	err = json.Unmarshal([]byte(cfg.SlackSettings), &s)
+
+	s, err := deploy.UnmarshalSlack(cfg.SlackSettings)
 	if err != nil {
 		panic(err)
 	}

--- a/deploy/infra/bin/granted.ts
+++ b/deploy/infra/bin/granted.ts
@@ -30,7 +30,7 @@ if (stackTarget === "dev") {
   new DevGrantedStack(app, "GrantedDev", {
     cognitoDomainPrefix,
     stage,
-    providerConfig,
+    providerConfig: providerConfig || "{}",
     // We have inadvertently propagated this "granted-approvals-" through our dev tooling, so if we want to change this then it needs to be changed everywhere
     stackName: "granted-approvals-" + stage,
     idpType: idpType || "COGNITO",
@@ -38,7 +38,7 @@ if (stackTarget === "dev") {
     devConfig: null,
     adminGroupId: adminGroupId || "granted_administrators",
     samlMetadata: samlMetadata || "",
-    slackConfiguration: slackConfig || "",
+    slackConfiguration: slackConfig || "{}",
     identityProviderSyncConfiguration: identityConfig || "{}",
   });
 } else if (stackTarget === "prod") {

--- a/deploy/infra/lib/constructs/notifiers.ts
+++ b/deploy/infra/lib/constructs/notifiers.ts
@@ -63,7 +63,10 @@ export class Notifiers extends Construct {
       "EnableSlackEventRuleCondition",
       {
         expression: Fn.conditionNot(
-          Fn.conditionEquals(props.slackConfiguration, "")
+          Fn.conditionOr(
+            Fn.conditionEquals(props.slackConfiguration, ""),
+            Fn.conditionEquals(props.slackConfiguration, "{}")
+          )
         ),
       }
     );

--- a/deploy/infra/lib/granted-approvals-stack-prod.ts
+++ b/deploy/infra/lib/granted-approvals-stack-prod.ts
@@ -81,12 +81,12 @@ export class CustomerGrantedStack extends cdk.Stack {
     const providerConfig = new CfnParameter(this, "ProviderConfiguration", {
       type: "String",
       description: "The Access Provider configuration in JSON format",
-      default: "",
+      default: "{}",
     });
     const slackConfig = new CfnParameter(this, "SlackConfiguration", {
       type: "String",
       description: "The Slack notifications configuration in JSON format",
-      default: "",
+      default: "{}",
     });
     const identityConfig = new CfnParameter(this, "IdentityConfiguration", {
       type: "String",

--- a/pkg/deploy/config.go
+++ b/pkg/deploy/config.go
@@ -39,11 +39,11 @@ var AvailableSSOProviders = []string{
 }
 
 type Config struct {
-	Version       int                 `yaml:"version"`
-	Deployment    Deployment          `yaml:"deployment"`
-	Providers     map[string]Provider `yaml:"providers,omitempty"`
-	Notifications *Notifications      `yaml:"notifications,omitempty"`
-	Identity      *IdentityConfig     `yaml:"identity,omitempty"`
+	Version       int                  `yaml:"version"`
+	Deployment    Deployment           `yaml:"deployment"`
+	Providers     map[string]Provider  `yaml:"providers,omitempty"`
+	Notifications *NotificationsConfig `yaml:"notifications,omitempty"`
+	Identity      *IdentityConfig      `yaml:"identity,omitempty"`
 
 	cachedOutput     *Output
 	cachedSAMLOutput *SAMLOutputs
@@ -56,7 +56,7 @@ type IdentityConfig struct {
 
 // UnmarshalIdentity parses the JSON configuration data and returns
 // an initialised struct. If `data` is an empty string an empty
-// Identity{} object is returned.
+// IdentityConfig{} object is returned.
 func UnmarshalIdentity(data string) (IdentityConfig, error) {
 	if data == "" {
 		return IdentityConfig{}, nil
@@ -92,16 +92,46 @@ func (o Okta) String() string {
 	return fmt.Sprintf("{APIToken: %s, OrgURL: %s}", o.APIToken, o.OrgURL)
 }
 
-type Notifications struct {
-	Slack *Slack `yaml:"slack,omitempty" json:"slack,omitempty"`
+type NotificationsConfig struct {
+	Slack *SlackConfig `yaml:"slack,omitempty" json:"slack,omitempty"`
 }
 
-type Slack struct {
+// UnmarshalNotifications parses the JSON configuration data and returns
+// an initialised struct. If `data` is an empty string an empty
+// NotificationsConfig{} object is returned.
+func UnmarshalNotifications(data string) (NotificationsConfig, error) {
+	if data == "" {
+		return NotificationsConfig{}, nil
+	}
+	var i NotificationsConfig
+	err := json.Unmarshal([]byte(data), &i)
+	if err != nil {
+		return NotificationsConfig{}, err
+	}
+	return i, nil
+}
+
+type SlackConfig struct {
 	APIToken string `yaml:"apiToken" json:"apiToken"`
 }
 
+// UnmarshalSlack parses the JSON configuration data and returns
+// an initialised struct. If `data` is an empty string an empty
+// SlackConfig{} object is returned.
+func UnmarshalSlack(data string) (SlackConfig, error) {
+	if data == "" {
+		return SlackConfig{}, nil
+	}
+	var i SlackConfig
+	err := json.Unmarshal([]byte(data), &i)
+	if err != nil {
+		return SlackConfig{}, err
+	}
+	return i, nil
+}
+
 // String redacts potentially sensitive token values
-func (s Slack) String() string {
+func (s SlackConfig) String() string {
 	s.APIToken = "****"
 	return fmt.Sprintf("{APIToken: %s}", s.APIToken)
 }

--- a/pkg/deploy/secrets_test.go
+++ b/pkg/deploy/secrets_test.go
@@ -14,7 +14,7 @@ func TestSSMSecretsAreMaskedWhenLogged(t *testing.T) {
 	google := Google{
 		APIToken: "this-should-be-hidden",
 	}
-	slack := Slack{
+	slack := SlackConfig{
 		APIToken: "this-should-be-hidden",
 	}
 	type testcase struct {

--- a/pkg/notifiers/slack/notifier.go
+++ b/pkg/notifiers/slack/notifier.go
@@ -20,7 +20,7 @@ type IdentityProvider interface {
 type Notifier struct {
 	DB          ddb.Storage
 	FrontendURL string
-	SlackConfig deploy.Slack
+	SlackConfig deploy.SlackConfig
 }
 
 func (n *Notifier) HandleEvent(ctx context.Context, event events.CloudWatchEvent) (err error) {

--- a/pkg/notifiers/slack/test_message.go
+++ b/pkg/notifiers/slack/test_message.go
@@ -12,7 +12,7 @@ import (
 // SendTestMessage is a helper used for customers to test their slack integration settings
 // it expects the configuration json as an input which is parsed and loaded from ssm
 func SendTestMessage(ctx context.Context, email string, slackConfig []byte) error {
-	var s deploy.Slack
+	var s deploy.SlackConfig
 	err := json.Unmarshal(slackConfig, &s)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR ensures that we have the correct default values for slack and access handler config.
I have added an unmarshaller for slackconfig and a default check for the access handler provider config