### PR TITLE
CF-1146: Check credentials are valid

### DIFF
--- a/cmd/gdeploy/commands/backup/backup.go
+++ b/cmd/gdeploy/commands/backup/backup.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"time"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -25,6 +26,9 @@ var Command = cli.Command{
 		f := c.Path("file")
 
 		dc := deploy.MustLoadConfig(f)
+
+		// Ensure aws account session is valid
+		deploy.MustGetCurrentAccountID(ctx, deploy.WithWarnExpiryIfWithinDuration(time.Minute))
 
 		stackOutput, err := dc.LoadOutput(ctx)
 		if err != nil {

--- a/cmd/gdeploy/commands/backup/status.go
+++ b/cmd/gdeploy/commands/backup/status.go
@@ -1,6 +1,8 @@
 package backup
 
 import (
+	"time"
+
 	"github.com/common-fate/granted-approvals/pkg/clio"
 	"github.com/common-fate/granted-approvals/pkg/deploy"
 	"github.com/urfave/cli/v2"
@@ -15,6 +17,8 @@ var BackupStatus = cli.Command{
 	Subcommands: []*cli.Command{},
 	Action: func(c *cli.Context) error {
 		ctx := c.Context
+		// Ensure aws account session is valid
+		deploy.MustGetCurrentAccountID(ctx, deploy.WithWarnExpiryIfWithinDuration(time.Minute))
 		backupOutput, err := deploy.BackupStatus(ctx, c.String("arn"))
 		if err != nil {
 			return err

--- a/cmd/gdeploy/commands/create.go
+++ b/cmd/gdeploy/commands/create.go
@@ -19,7 +19,7 @@ var CreateCommand = cli.Command{
 		ctx := c.Context
 
 		// Ensure aws account session is valid
-		deploy.MustGetCurrentAccountID(ctx, deploy.WithWarnExpiryIfWithinDuration(time.Minute))
+		deploy.MustGetCurrentAccountID(ctx, deploy.WithWarnExpiryIfWithinDuration(time.Minute * 10))
 
 		f := c.Path("file")
 

--- a/cmd/gdeploy/commands/create.go
+++ b/cmd/gdeploy/commands/create.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"time"
+
 	"github.com/common-fate/granted-approvals/pkg/clio"
 	"github.com/common-fate/granted-approvals/pkg/deploy"
 	"github.com/urfave/cli/v2"
@@ -15,6 +17,9 @@ var CreateCommand = cli.Command{
 	},
 	Action: func(c *cli.Context) error {
 		ctx := c.Context
+
+		// Ensure aws account session is valid
+		deploy.MustGetCurrentAccountID(ctx, deploy.WithWarnExpiryIfWithinDuration(time.Minute))
 
 		f := c.Path("file")
 

--- a/cmd/gdeploy/commands/logs/get.go
+++ b/cmd/gdeploy/commands/logs/get.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/TylerBrock/saw/blade"
 	sawconfig "github.com/TylerBrock/saw/config"
@@ -44,6 +45,9 @@ var getCommand = cli.Command{
 			dc := deploy.MustLoadConfig(f)
 			stackName = dc.Deployment.StackName
 		}
+
+		// Ensure aws account session is valid
+		deploy.MustGetCurrentAccountID(ctx, deploy.WithWarnExpiryIfWithinDuration(time.Minute))
 
 		client := cloudformation.NewFromConfig(cfg)
 		res, err := client.DescribeStacks(ctx, &cloudformation.DescribeStacksInput{

--- a/cmd/gdeploy/commands/logs/watch.go
+++ b/cmd/gdeploy/commands/logs/watch.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/TylerBrock/saw/blade"
 	sawconfig "github.com/TylerBrock/saw/config"
@@ -40,6 +41,9 @@ var watchCommand = cli.Command{
 			dc := deploy.MustLoadConfig(f)
 			stackName = dc.Deployment.StackName
 		}
+
+		// Ensure aws account session is valid
+		deploy.MustGetCurrentAccountID(ctx, deploy.WithWarnExpiryIfWithinDuration(time.Minute))
 
 		client := cloudformation.NewFromConfig(cfg)
 		res, err := client.DescribeStacks(ctx, &cloudformation.DescribeStacksInput{

--- a/cmd/gdeploy/commands/provider/add.go
+++ b/cmd/gdeploy/commands/provider/add.go
@@ -45,6 +45,9 @@ var addCommand = cli.Command{
 		f := c.Path("file")
 		dc := deploy.MustLoadConfig(f)
 
+		// Ensure aws account session is valid
+		deploy.MustGetCurrentAccountID(c.Context, deploy.WithWarnExpiryIfWithinDuration(time.Minute))
+
 		var id string
 		err = survey.AskOne(&survey.Input{
 			Message: "The ID for the provider",

--- a/cmd/gdeploy/commands/status.go
+++ b/cmd/gdeploy/commands/status.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"time"
+
 	"github.com/common-fate/granted-approvals/pkg/clio"
 	"github.com/common-fate/granted-approvals/pkg/deploy"
 	"github.com/urfave/cli/v2"
@@ -11,6 +13,9 @@ var StatusCommand = cli.Command{
 	Description: "Check the status of a Granted deployment",
 	Action: func(c *cli.Context) error {
 		ctx := c.Context
+
+		// Ensure aws account session is valid
+		deploy.MustGetCurrentAccountID(ctx, deploy.WithWarnExpiryIfWithinDuration(time.Minute))
 
 		f := c.Path("file")
 		dc := deploy.MustLoadConfig(f)

--- a/cmd/gdeploy/commands/sync/command.go
+++ b/cmd/gdeploy/commands/sync/command.go
@@ -1,6 +1,8 @@
 package sync
 
 import (
+	"time"
+
 	"github.com/common-fate/granted-approvals/pkg/clio"
 	"github.com/common-fate/granted-approvals/pkg/config"
 	"github.com/common-fate/granted-approvals/pkg/deploy"
@@ -14,6 +16,9 @@ var SyncCommand = cli.Command{
 	Name: "sync",
 	Action: func(c *cli.Context) error {
 		ctx := c.Context
+
+		// Ensure aws account session is valid
+		deploy.MustGetCurrentAccountID(ctx, deploy.WithWarnExpiryIfWithinDuration(time.Minute))
 
 		var cfg config.SyncConfig
 		_ = godotenv.Load()

--- a/cmd/gdeploy/commands/update.go
+++ b/cmd/gdeploy/commands/update.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"time"
+
 	"github.com/common-fate/granted-approvals/pkg/clio"
 	"github.com/common-fate/granted-approvals/pkg/deploy"
 	"github.com/urfave/cli/v2"
@@ -17,6 +19,9 @@ var UpdateCommand = cli.Command{
 		ctx := c.Context
 
 		f := c.Path("file")
+
+		// Ensure aws account session is valid
+		deploy.MustGetCurrentAccountID(ctx, deploy.WithWarnExpiryIfWithinDuration(time.Minute))
 
 		dc := deploy.MustLoadConfig(f)
 

--- a/cmd/gdeploy/commands/users/users.go
+++ b/cmd/gdeploy/commands/users/users.go
@@ -2,6 +2,7 @@ package users
 
 import (
 	"os"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
@@ -29,6 +30,9 @@ var createCommand = cli.Command{
 		if err != nil {
 			return err
 		}
+
+		// Ensure aws account session is valid
+		deploy.MustGetCurrentAccountID(ctx, deploy.WithWarnExpiryIfWithinDuration(time.Minute))
 
 		username := c.String("username")
 		f := c.Path("file")

--- a/pkg/deploy/backup.go
+++ b/pkg/deploy/backup.go
@@ -33,6 +33,9 @@ func BackupStatus(ctx context.Context, backupARN string) (*ddbTypes.BackupDescri
 	if err != nil {
 		return nil, err
 	}
+	// Ensure aws account session is valid
+	MustGetCurrentAccountID(ctx, WithWarnExpiryIfWithinDuration(time.Minute))
+
 	client := dynamodb.NewFromConfig(cfg)
 	b, err := client.DescribeBackup(ctx, &dynamodb.DescribeBackupInput{
 		BackupArn: &backupARN,
@@ -74,6 +77,9 @@ func RestoreStatus(ctx context.Context, targetTableName string) (*ddbTypes.Table
 	if err != nil {
 		return nil, err
 	}
+	// Ensure aws account session is valid
+	MustGetCurrentAccountID(ctx, WithWarnExpiryIfWithinDuration(time.Minute))
+
 	client := dynamodb.NewFromConfig(cfg)
 	rbo, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{
 		TableName: &targetTableName,

--- a/pkg/deploy/output.go
+++ b/pkg/deploy/output.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
@@ -169,6 +170,8 @@ func (c *Config) LoadOutput(ctx context.Context) (Output, error) {
 	if c.cachedOutput != nil {
 		return *c.cachedOutput, nil
 	}
+	// Ensure aws account session is valid
+	MustGetCurrentAccountID(ctx, WithWarnExpiryIfWithinDuration(time.Minute))
 
 	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(c.Deployment.Region))
 	if err != nil {


### PR DESCRIPTION
Running `gdeploy` commands now checks `MustGetCurrentAccountID` to ensure session is valid prior to running dependent commands 

<img width="562" alt="image" src="https://user-images.githubusercontent.com/21688404/178389248-4347a528-9144-4615-b198-62ad0271f974.png">
