### PR TITLE
gdeploy: add commands to get/set release version

### DIFF
--- a/cmd/gdeploy/commands/release/get.go
+++ b/cmd/gdeploy/commands/release/get.go
@@ -1,0 +1,24 @@
+package release
+
+import (
+	"fmt"
+
+	"github.com/common-fate/granted-approvals/pkg/deploy"
+	"github.com/urfave/cli/v2"
+)
+
+var getCommand = cli.Command{
+	Name:  "get",
+	Usage: "get the release version specified in your Granted configuration file",
+	Action: func(c *cli.Context) error {
+		ctx := c.Context
+
+		dc, err := deploy.ConfigFromContext(ctx)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(dc.Deployment.Release)
+		return nil
+	},
+}

--- a/cmd/gdeploy/commands/release/release.go
+++ b/cmd/gdeploy/commands/release/release.go
@@ -1,0 +1,14 @@
+package release
+
+import (
+	"github.com/urfave/cli/v2"
+)
+
+var Command = cli.Command{
+	Name:   "release",
+	Action: cli.ShowSubcommandHelp,
+	Subcommands: []*cli.Command{
+		&getCommand,
+		&setCommand,
+	},
+}

--- a/cmd/gdeploy/commands/release/set.go
+++ b/cmd/gdeploy/commands/release/set.go
@@ -1,0 +1,38 @@
+package release
+
+import (
+	"github.com/common-fate/granted-approvals/pkg/clio"
+	"github.com/common-fate/granted-approvals/pkg/deploy"
+	"github.com/urfave/cli/v2"
+)
+
+var setCommand = cli.Command{
+	Name:      "set",
+	Usage:     "set the release version in your Granted configuration file",
+	UsageText: "gdeploy release set <VERSION>",
+	Action: func(c *cli.Context) error {
+		ctx := c.Context
+
+		dc, err := deploy.ConfigFromContext(ctx)
+		if err != nil {
+			return err
+		}
+
+		version := c.Args().First()
+		if version == "" {
+			return clio.NewCLIError("You need to provide a version. Usage: gdeploy release set <VERSION>")
+		}
+
+		dc.Deployment.Release = version
+
+		f := c.Path("file")
+
+		err = dc.Save(f)
+		if err != nil {
+			return err
+		}
+
+		clio.Success("Set release version to %s", version)
+		return nil
+	},
+}

--- a/cmd/gdeploy/main.go
+++ b/cmd/gdeploy/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/common-fate/granted-approvals/cmd/gdeploy/commands/logs"
 	"github.com/common-fate/granted-approvals/cmd/gdeploy/commands/notifications"
 	"github.com/common-fate/granted-approvals/cmd/gdeploy/commands/provider"
+	"github.com/common-fate/granted-approvals/cmd/gdeploy/commands/release"
 	"github.com/common-fate/granted-approvals/cmd/gdeploy/commands/restore"
 	"github.com/common-fate/granted-approvals/cmd/gdeploy/commands/sso"
 	"github.com/common-fate/granted-approvals/cmd/gdeploy/commands/sync"
@@ -58,6 +59,7 @@ func main() {
 			WithBeforeFuncs(&notifications.Command, RequireDeploymentConfig(), RequireAWSCredentials()),
 			WithBeforeFuncs(&dashboard.Command, RequireDeploymentConfig(), RequireAWSCredentials()),
 			WithBeforeFuncs(&commands.InitCommand, RequireAWSCredentials()),
+			WithBeforeFuncs(&release.Command, RequireDeploymentConfig()),
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -139,7 +139,6 @@ require (
 	github.com/aws/aws-lambda-go v1.32.0
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.9.6
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.18.2
-	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.18.6
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.15.10
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.15.4
 	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.16.2

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,6 @@ github.com/aws/aws-sdk-go-v2/service/cloudformation v1.21.2 h1:fOsqTEkAm+z1fIXOz
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.21.2/go.mod h1:feeb/bUX013g5XC4v9DRvFwZNZu0CqhAHZhRA1GGK0E=
 github.com/aws/aws-sdk-go-v2/service/cloudfront v1.18.2 h1:uhpcmaxRKPt/VHGmzJ4aam8sL0DYr7qJejiQzp/dBV8=
 github.com/aws/aws-sdk-go-v2/service/cloudfront v1.18.2/go.mod h1:TRXCqcApTM1LhOJcLNolqFEDr3InJoYBieb1qqPcCko=
-github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.18.6 h1:3FtKgndLdv919p3V4VStk8y3agcC9yEu9vrhhe+rvfQ=
-github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.18.6/go.mod h1:A9gdtslk61CskUB2nDcY2fuvJ1RNl5bskr1eTJrcUJU=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.15.10 h1:i4iFDBClrtYE/l5diOkDkfDT4inFk3x/CtJ0wLp/13A=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.15.10/go.mod h1:qZ+mnaag/eWCF6gNVIVwjCjXuNbE0BuWJWKWh2TRAJ8=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.15.4 h1:sMzxamrhhkUrL/Ok7OyeJbJR46u4dbXOci0ucsOQu1c=


### PR DESCRIPTION
makes it easier to run gdeploy in CI/CD deployments.