### PR TITLE
fix branch deployment certificate ARNs

### DIFF
--- a/deploy/infra/lib/helpers/dev-accounts.ts
+++ b/deploy/infra/lib/helpers/dev-accounts.ts
@@ -3,5 +3,21 @@ export interface DevEnvironmentConfig {
   domainName: string;
   sharedCognitoUserPoolId: string;
   sharedCognitoUserPoolDomain: string;
-  account: string;
 }
+
+/**
+ * DevEnvironments are Common Fate test accounts that our CI pipelines
+ * create branch deployments in.
+ */
+export const DevEnvironments = new Map<string, DevEnvironmentConfig>([
+  [
+    "test",
+    {
+      certificateArn:
+        "arn:aws:acm:us-east-1:963589028267:certificate/55db5633-5e2e-4b26-b37f-d07248997bfd",
+      domainName: "test.granted.run",
+      sharedCognitoUserPoolDomain: "granted-test",
+      sharedCognitoUserPoolId: "us-east-1_Q0RLaRTOY",
+    },
+  ],
+]);

--- a/go.mod
+++ b/go.mod
@@ -139,7 +139,6 @@ require (
 	github.com/aws/aws-lambda-go v1.32.0
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.9.6
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.18.2
-	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.18.6
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.15.10
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.15.4
 	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.16.2

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,6 @@ github.com/aws/aws-sdk-go-v2/service/cloudformation v1.21.2 h1:fOsqTEkAm+z1fIXOz
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.21.2/go.mod h1:feeb/bUX013g5XC4v9DRvFwZNZu0CqhAHZhRA1GGK0E=
 github.com/aws/aws-sdk-go-v2/service/cloudfront v1.18.2 h1:uhpcmaxRKPt/VHGmzJ4aam8sL0DYr7qJejiQzp/dBV8=
 github.com/aws/aws-sdk-go-v2/service/cloudfront v1.18.2/go.mod h1:TRXCqcApTM1LhOJcLNolqFEDr3InJoYBieb1qqPcCko=
-github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.18.6 h1:3FtKgndLdv919p3V4VStk8y3agcC9yEu9vrhhe+rvfQ=
-github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.18.6/go.mod h1:A9gdtslk61CskUB2nDcY2fuvJ1RNl5bskr1eTJrcUJU=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.15.10 h1:i4iFDBClrtYE/l5diOkDkfDT4inFk3x/CtJ0wLp/13A=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.15.10/go.mod h1:qZ+mnaag/eWCF6gNVIVwjCjXuNbE0BuWJWKWh2TRAJ8=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.15.4 h1:sMzxamrhhkUrL/Ok7OyeJbJR46u4dbXOci0ucsOQu1c=

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -312,6 +312,8 @@ func (Deploy) StagingCDK(env, name string) error {
 
 	dep := deploy.NewStagingConfig(context.Background(), name)
 	args = append(args, dep.CDKContextArgs()...)
+	// add the devEnvironment context arg
+	args = append(args, "-c", "devEnvironment", env)
 
 	zap.S().Infow("deploying CDK stack", "stage", name)
 

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -313,7 +313,7 @@ func (Deploy) StagingCDK(env, name string) error {
 	dep := deploy.NewStagingConfig(context.Background(), name)
 	args = append(args, dep.CDKContextArgs()...)
 	// add the devEnvironment context arg
-	args = append(args, "-c", "devEnvironment", env)
+	args = append(args, "-c", "devEnvironment="+env)
 
 	zap.S().Infow("deploying CDK stack", "stage", name)
 


### PR DESCRIPTION
this is a band-aid fix to the custom URLs for our per-branch deployments not working.

I would prefer to use `gdeploy` to create branch deployments, but we don't yet support using an existing Cognito user pool. It's a lot more desirable to use one Cognito pool for testing, otherwise we need to provision users every single time we test.