### PR TITLE
add no cache headers

### DIFF
--- a/cmd/gdeploy/commands/create.go
+++ b/cmd/gdeploy/commands/create.go
@@ -33,7 +33,7 @@ var CreateCommand = cli.Command{
 			confirm = true
 		}
 
-		err = dc.DeployCloudFormation(ctx, confirm)
+		_, err = dc.DeployCloudFormation(ctx, confirm)
 		if err != nil {
 			return err
 		}

--- a/cmd/gdeploy/commands/update.go
+++ b/cmd/gdeploy/commands/update.go
@@ -31,7 +31,7 @@ var UpdateCommand = cli.Command{
 			confirm = true
 		}
 
-		err = dc.DeployCloudFormation(ctx, confirm)
+		status, err := dc.DeployCloudFormation(ctx, confirm)
 		if err != nil {
 			return err
 		}
@@ -41,8 +41,11 @@ var UpdateCommand = cli.Command{
 			return err
 		}
 		o.PrintTable()
-
-		clio.Success("Your Granted deployment has been updated")
+		if status == "UPDATE_COMPLETE" {
+			clio.Success("Your Granted deployment has been updated")
+		} else {
+			clio.Warn("Your Granted deployment update ended in status %s", status)
+		}
 
 		return nil
 	},

--- a/deploy/infra/lib/constructs/app-user-pool.ts
+++ b/deploy/infra/lib/constructs/app-user-pool.ts
@@ -224,9 +224,13 @@ export class SamlUserPoolClient extends Construct {
         logoutUrls: props.callbackUrls,
       },
     });
+
     // have to drill down into the L1 construct to set the condition here
     const c = this._userPoolClient.node.defaultChild as CfnUserPoolClient;
     c.cfnOptions.condition = props.condition;
+    // adding this depends on to ensure that the user pool client is not created until the saml CfnUserPoolIdentityProvider exists
+    // this avoids an error "The provider <PROVIDER NAME> does not exist for User Pool <POOL_ID>"
+    c.addDependsOn(this._idp);
   }
   getUserPoolClient(): cognito.UserPoolClient {
     return this._userPoolClient;

--- a/deploy/infra/lib/constructs/production-frontend-deployer.ts
+++ b/deploy/infra/lib/constructs/production-frontend-deployer.ts
@@ -78,8 +78,11 @@ export class ProductionFrontendDeployer extends Construct {
     // custom resource will deploy the frontend from the public releases bucket
     new CustomResource(this, "CustomResource", {
       serviceToken: this._lambda.functionArn,
+
+      // These properties will cause the custom resource to run during an update when the cognito client id changes or when the frontend assets path changes
       properties: {
         Release: props.cfReleaseBucketFrontendAssetObjectPrefix,
+        CognitoClientID: props.cognitoClientId,
       },
     });
   }

--- a/web/src/utils/context/userContext.tsx
+++ b/web/src/utils/context/userContext.tsx
@@ -103,7 +103,13 @@ const UserProvider: React.FC<Props> = ({ children }) => {
       setInitialized(true);
     } else {
       console.debug("using fetch to get aws-exports.json");
-      fetch("/aws-exports.json").then((r) =>
+      const awsConfigRequestHeaders = new Headers();
+      awsConfigRequestHeaders.append("pragma", "no-cache");
+      awsConfigRequestHeaders.append("cache-control", "no-cache");
+      fetch("/aws-exports.json", {
+        headers: awsConfigRequestHeaders,
+        method: "GET",
+      }).then((r) =>
         r.json().then((j) => {
           Amplify.configure(j);
           const apiURL = j.API.endpoints[0]?.endpoint;


### PR DESCRIPTION
This PR fixes the update pathway from cognito to SAML
- add no cache headers to aws-exports.json fetch
- add dependency to cloudformation template
- add dependency to frontend deployer customer resource for cognito client id