### PR TITLE
Cli fixes

### DIFF
--- a/cmd/gdeploy/commands/create.go
+++ b/cmd/gdeploy/commands/create.go
@@ -56,7 +56,7 @@ var CreateCommand = cli.Command{
 Check out the next steps in our getting started guide for more information: https://docs.comonfate.io/granted-approvals/getting-started/deploying
 `)
 		} else {
-			clio.Warn("Your Granted deployment update ended in status %s", status)
+			clio.Warn("Creating your Granted deployment failed with a final status: %s", status)
 			return nil
 		}
 

--- a/cmd/gdeploy/commands/create.go
+++ b/cmd/gdeploy/commands/create.go
@@ -33,7 +33,7 @@ var CreateCommand = cli.Command{
 			confirm = true
 		}
 
-		_, err = dc.DeployCloudFormation(ctx, confirm)
+		status, err := dc.DeployCloudFormation(ctx, confirm)
 		if err != nil {
 			return err
 		}
@@ -42,10 +42,12 @@ var CreateCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		o.PrintTable()
 
-		clio.Success("Your Granted deployment has been created")
-		clio.Info(`Here are your next steps to get started:
+		if status == "CREATE_COMPLETE" {
+			clio.Success("Your Granted deployment has been created")
+			o.PrintTable()
+
+			clio.Info(`Here are your next steps to get started:
 
   1) create an admin user so you can log in: 'gdeploy users create --admin -u YOUR_EMAIL_ADDRESS'
   2) add an Access Provider: 'gdeploy provider add'
@@ -53,6 +55,10 @@ var CreateCommand = cli.Command{
 
 Check out the next steps in our getting started guide for more information: https://docs.comonfate.io/granted-approvals/getting-started/deploying
 `)
+		} else {
+			clio.Warn("Your Granted deployment update ended in status %s", status)
+			return nil
+		}
 
 		return nil
 	},

--- a/cmd/gdeploy/commands/update.go
+++ b/cmd/gdeploy/commands/update.go
@@ -43,6 +43,10 @@ var UpdateCommand = cli.Command{
 		o.PrintTable()
 		if status == "UPDATE_COMPLETE" {
 			clio.Success("Your Granted deployment has been updated")
+		} else if status == "DEPLOY_SKIPPED" {
+			//return without displaying status, nothing changed
+			return nil
+
 		} else {
 			clio.Warn("Your Granted deployment update ended in status %s", status)
 		}

--- a/cmd/gdeploy/main.go
+++ b/cmd/gdeploy/main.go
@@ -176,8 +176,9 @@ func RequireAWSCredentials() cli.BeforeFunc {
 			return clio.NewCLIError("Failed to call AWS get caller identity. (maybe you need to assume a role first?)", clio.DebugMsg(err.Error()))
 		}
 
+		overwrite := c.Bool("overwrite")
 		//check to see that account number in config is the same account that is assumed
-		if identity.Account != &dc.Deployment.Account {
+		if identity.Account != &dc.Deployment.Account && !overwrite {
 			return clio.NewCLIError(fmt.Sprintf("Deployment account mismatched assumed account: %s verses %s", dc.Deployment.Account, aws.StringValue(identity.Account)))
 		}
 		c.Context = cfaws.SetConfigInContext(ctx, cfg)

--- a/cmd/gdeploy/main.go
+++ b/cmd/gdeploy/main.go
@@ -176,9 +176,10 @@ func RequireAWSCredentials() cli.BeforeFunc {
 			return clio.NewCLIError("Failed to call AWS get caller identity. (maybe you need to assume a role first?)", clio.DebugMsg(err.Error()))
 		}
 
+		//allow the overwrite if overwrite is set
 		overwrite := c.Bool("overwrite")
 		//check to see that account number in config is the same account that is assumed
-		if identity.Account != &dc.Deployment.Account && !overwrite {
+		if *identity.Account != dc.Deployment.Account && !overwrite {
 			return clio.NewCLIError(fmt.Sprintf("Deployment account mismatched assumed account: %s verses %s", dc.Deployment.Account, aws.StringValue(identity.Account)))
 		}
 		c.Context = cfaws.SetConfigInContext(ctx, cfg)

--- a/cmd/gdeploy/main.go
+++ b/cmd/gdeploy/main.go
@@ -176,7 +176,7 @@ func RequireAWSCredentials() cli.BeforeFunc {
 		}
 
 		//check to see that account number in config is the same account that is assumed
-		if *identity.Account != dc.Deployment.Account && !overwrite {
+		if *identity.Account != dc.Deployment.Account {
 			return clio.NewCLIError(fmt.Sprintf("AWS account in your deployment config %s does not match the account of your current AWS credentials %s", dc.Deployment.Account, *identity.Account), clio.LogMsg("Please export valid AWS credentials for account %s to run this command.", *identity.Account))
 		}
 		c.Context = cfaws.SetConfigInContext(ctx, cfg)

--- a/cmd/gdeploy/main.go
+++ b/cmd/gdeploy/main.go
@@ -172,7 +172,7 @@ func RequireAWSCredentials() cli.BeforeFunc {
 			if errors.As(err, &ae) && ae.ErrorCode() == "ExpiredToken" {
 				return clio.NewCLIError("AWS credentials are expired.", clio.LogMsg("Please export valid AWS credentials to run this command."))
 			}
-			return clio.NewCLIError("Failed to call AWS get caller identity", clio.DebugMsg(err.Error()))
+			return clio.NewCLIError("Failed to call AWS get caller identity. (maybe you need to assume a role first?)", clio.DebugMsg(err.Error()))
 		}
 		c.Context = cfaws.SetConfigInContext(ctx, cfg)
 		return nil

--- a/cmd/gdeploy/main.go
+++ b/cmd/gdeploy/main.go
@@ -175,10 +175,8 @@ func RequireAWSCredentials() cli.BeforeFunc {
 			return clio.NewCLIError("Failed to call AWS get caller identity. ", clio.LogMsg("Please export valid AWS credentials to run this command."), clio.DebugMsg(err.Error()))
 		}
 
-		//allow the overwrite if overwrite is set
-		overwrite := c.Bool("overwrite")
 		//check to see that account number in config is the same account that is assumed
-		if *identity.Account != dc.Deployment.Account && !overwrite {
+		if *identity.Account != dc.Deployment.Account {
 			return clio.NewCLIError(fmt.Sprintf("AWS account in your deployment config %s does not match the account of your current AWS credentials %s", dc.Deployment.Account, *identity.Account), clio.LogMsg("Please export valid AWS credentials for account %s to run this command."))
 		}
 		c.Context = cfaws.SetConfigInContext(ctx, cfg)

--- a/cmd/gdeploy/main.go
+++ b/cmd/gdeploy/main.go
@@ -179,7 +179,7 @@ func RequireAWSCredentials() cli.BeforeFunc {
 		overwrite := c.Bool("overwrite")
 		//check to see that account number in config is the same account that is assumed
 		if *identity.Account != dc.Deployment.Account && !overwrite {
-			return clio.NewCLIError(fmt.Sprintf("AWS account in your deployment config %s does not match the account of your current AWS credentials %s", dc.Deployment.Account, *identity.Account), clio.LogMsg("Please export valid AWS credentials for account %s to run this command."))
+			return clio.NewCLIError(fmt.Sprintf("AWS account in your deployment config %s does not match the account of your current AWS credentials %s", dc.Deployment.Account, *identity.Account), clio.LogMsg("Please export valid AWS credentials for account %s to run this command.",*identity.Account))
 		}
 		c.Context = cfaws.SetConfigInContext(ctx, cfg)
 		return nil

--- a/pkg/deploy/config.go
+++ b/pkg/deploy/config.go
@@ -436,11 +436,10 @@ func SetupReleaseConfig(c *cli.Context) (*Config, error) {
 		}
 	}
 
-	//Setting account to a fresh variable when set, was being unallocated when using the account variable
-	//var acc string
 	account := c.String("account")
 	if account == "" {
 		ctx := context.Background()
+		//Setting account to a fresh variable when set, was being unallocated when using the account variable
 		current, err := tryGetCurrentAccountID(ctx)
 		if err != nil {
 			return nil, err

--- a/pkg/deploy/config.go
+++ b/pkg/deploy/config.go
@@ -436,14 +436,16 @@ func SetupReleaseConfig(c *cli.Context) (*Config, error) {
 		}
 	}
 
+	//Setting account to a fresh variable when set, was being unallocated when using the account variable
+	//var acc string
 	account := c.String("account")
 	if account == "" {
 		ctx := context.Background()
-		account, err := tryGetCurrentAccountID(ctx)
+		current, err := tryGetCurrentAccountID(ctx)
 		if err != nil {
 			return nil, err
 		}
-		p := &survey.Input{Message: "The account ID that you are deploying to", Default: account}
+		p := &survey.Input{Message: "The account ID that you are deploying to", Default: current}
 		err = survey.AskOne(p, &account)
 		if err != nil {
 			return nil, err

--- a/pkg/deploy/deploy_cfn.go
+++ b/pkg/deploy/deploy_cfn.go
@@ -44,7 +44,7 @@ func (c *Config) DeployCloudFormation(ctx context.Context, confirm bool) (string
 	if createErr != nil {
 		if createErr.Error() == noChangeFoundMsg {
 			clio.Success("Change set was created, but there is no change. Deploy was skipped.")
-			return "", nil
+			return "DEPLOY_SKIPPED", nil
 		} else {
 			return "", errors.Wrap(createErr, "creating changeset")
 		}


### PR DESCRIPTION
Add check in AWS creds before, to check that the assumed role is for the same account as what is in the granted config
Fix bug causing account not to be saved to the config
Fixed UI in CLI when updating changeset has no changes
Check the status when creating stack and only display table + instructions after success