### PR TITLE
Bug fixes for idp and providers

### DIFF
--- a/docs/backend/backend.md
+++ b/docs/backend/backend.md
@@ -21,6 +21,25 @@ If you create a new endpoint and generate the code for it, you will need to make
 GetApiV1Rules(w http.ResponseWriter, r *http.Request)
 ```
 
+### Implementing List API responses
+
+When implementing a List API, first you will create a a listResponse type following our openapi-standards.
+Then in the api stub, it is critical to follow this pattern for the response.
+In Go, a nil slice will marshal to JSON as null rather than an empty array.
+This breaks our frontend typing and causes errors.
+
+To avoid this, always initialise the list response using make([]types.ResponseType, len(responseElements)) as below
+This will make a non nil empty slice if there are no elements which marshals to [] in JSON.
+
+```go
+res := types.ListGroupsResponse{
+    Groups: make([]types.Group, len(q.Result)),
+}
+for i, g := range q.Result {
+    res.Groups[i] = g.ToAPI()
+}
+```
+
 ## Webhook Handler
 
 When deployed, the backend API runs in AWS Lambda, behind AWS API Gateway. The API Gateway handles Cognito authentication.

--- a/pkg/api/groups.go
+++ b/pkg/api/groups.go
@@ -26,10 +26,12 @@ func (a *API) GetGroups(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res := types.ListGroupsResponse{}
+	res := types.ListGroupsResponse{
+		Groups: make([]types.Group, len(q.Result)),
+	}
 
-	for _, u := range q.Result {
-		res.Groups = append(res.Groups, u.ToAPI())
+	for i, g := range q.Result {
+		res.Groups[i] = g.ToAPI()
 	}
 
 	apio.JSON(ctx, w, res, http.StatusOK)

--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -38,10 +38,10 @@ func (a *API) UserListRequestsUpcoming(w http.ResponseWriter, r *http.Request) {
 	}
 
 	res := types.ListRequestsResponse{
-		Requests: []types.Request{},
+		Requests: make([]types.Request, len(q.Result)),
 	}
-	for _, req := range q.Result {
-		res.Requests = append(res.Requests, req.ToAPI())
+	for i, r := range q.Result {
+		res.Requests[i] = r.ToAPI()
 	}
 	apio.JSON(ctx, w, res, http.StatusOK)
 }
@@ -66,10 +66,10 @@ func (a *API) UserListRequestsPast(w http.ResponseWriter, r *http.Request) {
 	}
 
 	res := types.ListRequestsResponse{
-		Requests: []types.Request{},
+		Requests: make([]types.Request, len(q.Result)),
 	}
-	for _, req := range q.Result {
-		res.Requests = append(res.Requests, req.ToAPI())
+	for i, r := range q.Result {
+		res.Requests[i] = r.ToAPI()
 	}
 	apio.JSON(ctx, w, res, http.StatusOK)
 }
@@ -120,11 +120,10 @@ func (a *API) UserListRequests(w http.ResponseWriter, r *http.Request, params ty
 	res := types.ListRequestsResponse{
 		Requests: make([]types.Request, len(requests)),
 	}
-	if len(requests) > 0 {
-		for i, r := range requests {
-			res.Requests[i] = r.ToAPI()
-		}
+	for i, r := range requests {
+		res.Requests[i] = r.ToAPI()
 	}
+
 	apio.JSON(ctx, w, res, http.StatusOK)
 }
 
@@ -371,8 +370,9 @@ func (a *API) ListRequestEvents(w http.ResponseWriter, r *http.Request, requestI
 		apio.Error(ctx, w, err)
 		return
 	}
-	var res types.ListRequestEventsResponse
-	res.Events = make([]types.RequestEvent, len(qre.Result))
+	res := types.ListRequestEventsResponse{
+		Events: make([]types.RequestEvent, len(qre.Result)),
+	}
 	for i, re := range qre.Result {
 		res.Events[i] = re.ToAPI()
 	}

--- a/pkg/api/request_admin.go
+++ b/pkg/api/request_admin.go
@@ -60,11 +60,12 @@ func (a *API) AdminListRequests(w http.ResponseWriter, r *http.Request, params t
 	}
 
 	// var endToken int
-	var res types.ListRequestsResponse
-	res.Requests = []types.Request{}
+	res := types.ListRequestsResponse{
+		Requests: make([]types.Request, len(dbRes)),
+	}
 
-	for _, r := range dbRes {
-		res.Requests = append(res.Requests, r.ToAPI())
+	for i, r := range dbRes {
+		res.Requests[i] = r.ToAPI()
 	}
 
 	res.Next = next

--- a/pkg/api/users.go
+++ b/pkg/api/users.go
@@ -24,10 +24,12 @@ func (a *API) GetUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res := types.ListUserResponse{}
+	res := types.ListUserResponse{
+		Users: make([]types.User, len(q.Result)),
+	}
 
-	for _, u := range q.Result {
-		res.Users = append(res.Users, u.ToAPI())
+	for i, u := range q.Result {
+		res.Users[i] = u.ToAPI()
 	}
 
 	apio.JSON(ctx, w, res, http.StatusOK)

--- a/pkg/identity/identitysync/sync.go
+++ b/pkg/identity/identitysync/sync.go
@@ -178,6 +178,7 @@ func processUsersAndGroups(idpUsers []identity.IdpUser, idpGroups []identity.Idp
 		if existing, ok := ddbGroupMap[g.ID]; ok { //update
 			existing.Description = g.Description
 			existing.Name = g.Name
+			existing.Status = types.IdpStatusACTIVE
 			ddbGroupMap[g.ID] = existing
 		} else { // create
 			newGroup := g.ToInternalGroup()

--- a/pkg/identity/identitysync/sync_test.go
+++ b/pkg/identity/identitysync/sync_test.go
@@ -214,6 +214,42 @@ func TestIdentitySyncProcessor(t *testing.T) {
 				},
 			},
 		},
+		{
+			// a group should be dearchived if it exists again
+			name:         "dearchive group when it exists again",
+			giveIdpUsers: []identity.IdpUser{},
+			giveIdpGroups: []identity.IdpGroup{{
+				ID:          "granted_administrators",
+				Name:        "granted_administrators",
+				Description: "admin group",
+			}},
+			giveInternalUsers: []identity.User{},
+			giveInternalGroups: []identity.Group{
+				{
+					ID:          "1234",
+					IdpID:       "granted_administrators",
+					Name:        "granted_administrators",
+					Description: "admin group",
+					Status:      types.IdpStatusARCHIVED,
+					Users:       []string{},
+					CreatedAt:   now,
+					UpdatedAt:   now,
+				},
+			},
+			wantUserMap: map[string]identity.User{},
+			wantGroupMap: map[string]identity.Group{
+				"granted_administrators": {
+					ID:          "1234",
+					IdpID:       "granted_administrators",
+					Name:        "granted_administrators",
+					Description: "admin group",
+					Status:      types.IdpStatusACTIVE,
+					Users:       []string{},
+					CreatedAt:   now,
+					UpdatedAt:   now,
+				},
+			},
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Ensure that IDP groups which are archived can be dearchived if they become active again.
Ensure that all list responses in the API have a default empty slice assigned so that a null value is not returned