### PR TITLE
Ux improvements for sso

### DIFF
--- a/cmd/gdeploy/commands/sso/sso.go
+++ b/cmd/gdeploy/commands/sso/sso.go
@@ -257,7 +257,7 @@ var configureCommand = cli.Command{
 Create a group called 'Granted Administrators' in your identity provider and copy the group's ID.
 Users in this group will be able to manage Access Rules.
 `)
-		adminGroupPrompt := &survey.Input{Message: "The ID of the Granted Administrators group in your identity provider:"}
+		adminGroupPrompt := &survey.Input{Message: "The ID of the Granted Administrators group in your identity provider:", Default: dc.Deployment.Parameters.AdministratorGroupID}
 		err = survey.AskOne(adminGroupPrompt, &dc.Deployment.Parameters.AdministratorGroupID)
 		if err != nil {
 			return err

--- a/cmd/gdeploy/main.go
+++ b/cmd/gdeploy/main.go
@@ -42,8 +42,15 @@ func main() {
 		Flags: []cli.Flag{
 			&cli.PathFlag{Name: "file", Aliases: []string{"f"}, Value: "granted-deployment.yml", Usage: "the deployment config file"},
 			&cli.BoolFlag{Name: "ignore-git-dirty", Usage: "ignore checking if this is a clean repository during create and update commands"},
+			&cli.BoolFlag{Name: "verbose", Usage: "enable verbose logging, effectively sets environment variable GRANTED_LOG=DEBUG"},
 		},
 		Writer: color.Output,
+		Before: func(ctx *cli.Context) error {
+			if ctx.Bool("verbose") {
+				os.Setenv("GRANTED_LOG", "DEBUG")
+			}
+			return nil
+		},
 		Commands: []*cli.Command{
 			// It's possible that these wrappers would be better defined on the commands themselves rather than in this main function
 			// It would be easier to see exactly what runs when a command runs

--- a/cmd/gdeploy/main.go
+++ b/cmd/gdeploy/main.go
@@ -150,24 +150,33 @@ func RequireAWSCredentials() cli.BeforeFunc {
 		si.Writer = os.Stderr
 		si.Start()
 		defer si.Stop()
+		needCredentialsLog := clio.LogMsg("Please export valid AWS credentials to run this command.")
 		cfg, err := cfaws.ConfigFromContextOrDefault(ctx)
 		if err != nil {
-			return clio.NewCLIError("Failed to load AWS credentials.", clio.DebugMsg("Encountered error while loading default aws config: %s", err))
+			return clio.NewCLIError("Failed to load AWS credentials.", clio.DebugMsg("Encountered error while loading default aws config: %s", err), needCredentialsLog)
 		}
 
 		// Use the deployment region if it is available
+		var configExists bool
 		dc, err := deploy.ConfigFromContext(ctx)
-		if err == nil && dc.Deployment.Region != "" {
-			cfg.Region = dc.Deployment.Region
+		if err == nil {
+			configExists = true
+			if dc.Deployment.Region != "" {
+				cfg.Region = dc.Deployment.Region
+			}
+			if dc.Deployment.Account != "" {
+				// include the account id in the log message if available
+				needCredentialsLog = clio.LogMsg("Please export valid AWS credentials for account %s to run this command.", dc.Deployment.Account)
+			}
 		}
 
 		creds, err := cfg.Credentials.Retrieve(ctx)
 		if err != nil {
-			return clio.NewCLIError("Failed to load AWS credentials.", clio.DebugMsg("Encountered error while loading default aws config: %s", err))
+			return clio.NewCLIError("Failed to load AWS credentials.", clio.DebugMsg("Encountered error while loading default aws config: %s", err), needCredentialsLog)
 		}
 
 		if !creds.HasKeys() {
-			return clio.NewCLIError("Could not find AWS credentials. Please export valid AWS credentials to run this command.", clio.LogMsg("Could not find AWS credentials. Please export valid AWS credentials to run this command."))
+			return clio.NewCLIError("Failed to load AWS credentials.", needCredentialsLog)
 		}
 
 		stsClient := sts.NewFromConfig(cfg)
@@ -177,14 +186,14 @@ func RequireAWSCredentials() cli.BeforeFunc {
 			var ae smithy.APIError
 			// the aws sdk doesn't seem to have a concrete type for ExpiredToken so instead we check the error code
 			if errors.As(err, &ae) && ae.ErrorCode() == "ExpiredToken" {
-				return clio.NewCLIError("AWS credentials are expired.", clio.LogMsg("Please export valid AWS credentials to run this command."))
+				return clio.NewCLIError("AWS credentials are expired.", needCredentialsLog)
 			}
-			return clio.NewCLIError("Failed to call AWS get caller identity. ", clio.LogMsg("Please export valid AWS credentials to run this command."), clio.DebugMsg(err.Error()))
+			return clio.NewCLIError("Failed to call AWS get caller identity. ", clio.DebugMsg(err.Error()), needCredentialsLog)
 		}
 
 		//check to see that account number in config is the same account that is assumed
-		if *identity.Account != dc.Deployment.Account {
-			return clio.NewCLIError(fmt.Sprintf("AWS account in your deployment config %s does not match the account of your current AWS credentials %s", dc.Deployment.Account, *identity.Account), clio.LogMsg("Please export valid AWS credentials for account %s to run this command.", *identity.Account))
+		if configExists && *identity.Account != dc.Deployment.Account {
+			return clio.NewCLIError(fmt.Sprintf("AWS account in your deployment config %s does not match the account of your current AWS credentials %s", dc.Deployment.Account, *identity.Account), needCredentialsLog)
 		}
 		c.Context = cfaws.SetConfigInContext(ctx, cfg)
 		return nil

--- a/pkg/identity/identitysync/azure.go
+++ b/pkg/identity/identitysync/azure.go
@@ -27,11 +27,18 @@ type ListUsersResponse struct {
 	Value         []AzureUser `json:"value"`
 }
 
+// properties of a user in the graph API
+//
+// https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties
 type AzureUser struct {
 	GivenName string `json:"givenName"`
-	Mail      string `json:"mail"`
-	Surname   string `json:"surname"`
-	ID        string `json:"id"`
+	// this maps to a users email by convention
+	// see the graph API spec for details
+	// in practive all users have a principal name but some users may not have the "mail" property for different reasons.
+	// we use this for the email
+	UserPrincipalName string `json:"userPrincipalName"`
+	Surname           string `json:"surname"`
+	ID                string `json:"id"`
 }
 
 type ListGroupsResponse struct {
@@ -96,7 +103,7 @@ func (a *AzureSync) idpUserFromAzureUser(ctx context.Context, azureUser AzureUse
 		ID:        azureUser.ID,
 		FirstName: azureUser.GivenName,
 		LastName:  azureUser.Surname,
-		Email:     azureUser.Mail,
+		Email:     azureUser.UserPrincipalName,
 		Groups:    []string{},
 	}
 


### PR DESCRIPTION
- in azure sync, replace user.mail with user.userPrimaryName
- in the gdeploy sync command, change logic to check for a lambda error so that the logs make sense if the lambda has failed.
- gdeploy aws credentials check needs to have consistent log message to inform users that aws is required to run this command.
- update the gdeploy sso cli to have a default value for group id if it is configured already