### PR TITLE
added basic auth error page and update auth logic to show on failed l…

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -83,12 +83,12 @@ func Middleware(authenticator Authenticator, db ddb.Storage, idp IdentitySyncer)
 			// which we can use for handling IDP webhook notifications rather than polling.
 			if err == ddb.ErrNoItems {
 				log.Info("user does not exist in database - running an IDP sync and trying again", "user", claims)
-				err = idp.Sync(ctx)
-				if err != nil {
-					log.Infow("error syncing IDP", zap.Error(err))
-					apio.ErrorString(ctx, w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
-					return
-				}
+				// err = idp.Sync(ctx)
+				// if err != nil {
+				// 	log.Infow("error syncing IDP", zap.Error(err))
+				// 	apio.ErrorString(ctx, w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+				// 	return
+				// }
 				log.Info("looking up user again")
 				// reuse the same query, so that we can access the results later if it's successful.
 				_, err = db.Query(ctx, q)

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -83,12 +83,12 @@ func Middleware(authenticator Authenticator, db ddb.Storage, idp IdentitySyncer)
 			// which we can use for handling IDP webhook notifications rather than polling.
 			if err == ddb.ErrNoItems {
 				log.Info("user does not exist in database - running an IDP sync and trying again", "user", claims)
-				// err = idp.Sync(ctx)
-				// if err != nil {
-				// 	log.Infow("error syncing IDP", zap.Error(err))
-				// 	apio.ErrorString(ctx, w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
-				// 	return
-				// }
+				err = idp.Sync(ctx)
+				if err != nil {
+					log.Infow("error syncing IDP", zap.Error(err))
+					apio.ErrorString(ctx, w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+					return
+				}
 				log.Info("looking up user again")
 				// reuse the same query, so that we can access the results later if it's successful.
 				_, err = db.Query(ctx, q)

--- a/web/src/pages/noUserPage.tsx
+++ b/web/src/pages/noUserPage.tsx
@@ -20,8 +20,8 @@ export const NoUser = (props: Props) => {
       <Stack textAlign="center" w="70%">
         <Heading pb="50px">An error occured signing you in</Heading>
         <Text>
-          You've successfully logged in, but we couldn&apos;t find a matching
-          user account for you in our database. ({props.userEmail})
+          You&apos;ve successfully logged in, but we couldn&apos;t find a
+          matching user account for you in our database. ({props.userEmail})
         </Text>
         <Text>
           This is likely because your user directory settings are misconfigured.

--- a/web/src/pages/noUserPage.tsx
+++ b/web/src/pages/noUserPage.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from "react-location";
 
 interface Props {
   userEmail?: string;
-  initiateAuth: () => Promise<ICredentials>;
+  initiateSignOut: () => Promise<any>;
 }
 
 export const NoUser = (props: Props) => {
@@ -42,7 +42,9 @@ export const NoUser = (props: Props) => {
         <Button
           onClick={() => {
             console.log("clicked");
-            window.location.reload();
+            props.initiateSignOut().then(() => {
+              window.location.reload();
+            });
           }}
           top="40px"
           alignSelf="center"

--- a/web/src/pages/noUserPage.tsx
+++ b/web/src/pages/noUserPage.tsx
@@ -18,7 +18,7 @@ export const NoUser = (props: Props) => {
       justifyContent="center"
     >
       <Stack textAlign="center" w="70%">
-        <Heading pb="50px">An error occured signing you in</Heading>
+        <Heading pb="50px">An error occurred signing you in</Heading>
         <Text>
           You&apos;ve successfully logged in, but we couldn&apos;t find a
           matching user account for you in our database. (

--- a/web/src/pages/noUserPage.tsx
+++ b/web/src/pages/noUserPage.tsx
@@ -20,8 +20,8 @@ export const NoUser = (props: Props) => {
       <Stack textAlign="center" w="70%">
         <Heading pb="50px">An error occured signing you in</Heading>
         <Text>
-          You've successfully logged in, but we couldn't find a matching user
-          account for you in our database. ({props.userEmail})
+          You've successfully logged in, but we couldn&apos;t find a matching
+          user account for you in our database. ({props.userEmail})
         </Text>
         <Text>
           This is likely because your user directory settings are misconfigured.

--- a/web/src/pages/noUserPage.tsx
+++ b/web/src/pages/noUserPage.tsx
@@ -1,0 +1,54 @@
+import { Flex, Text, Stack, Heading, Button } from "@chakra-ui/react";
+import { ICredentials } from "@aws-amplify/core";
+
+import { useNavigate } from "react-location";
+
+interface Props {
+  userEmail?: string;
+  initiateAuth: () => Promise<ICredentials>;
+}
+
+export const NoUser = (props: Props) => {
+  const navigate = useNavigate();
+  return (
+    <Flex
+      height="100vh"
+      padding="0"
+      alignItems="center"
+      justifyContent="center"
+    >
+      <Stack textAlign="center" w="70%">
+        <Heading pb="50px">An error occured signing you in</Heading>
+        <Text>
+          You've successfully logged in, but we couldn't find a matching user
+          account for you in our database. ({props.userEmail})
+        </Text>
+        <Text>
+          This is likely because your user directory settings are misconfigured.
+          Check that your configuration variables (including client IDs and
+          secrets) in your granted-deployment.yml file are correct.
+        </Text>
+
+        <Text>
+          If you need help debugging this, contact us at:{" "}
+          <a href="mailto:hello@commonfate.io">hello@commonfate.io</a>
+        </Text>
+
+        <Button
+          onClick={() => {
+            console.log("clicked");
+            window.location.reload();
+          }}
+          top="40px"
+          alignSelf="center"
+          size="md"
+          w="40%"
+        >
+          Back to login
+        </Button>
+      </Stack>
+    </Flex>
+  );
+};
+
+export default NoUser;

--- a/web/src/pages/noUserPage.tsx
+++ b/web/src/pages/noUserPage.tsx
@@ -21,7 +21,12 @@ export const NoUser = (props: Props) => {
         <Heading pb="50px">An error occured signing you in</Heading>
         <Text>
           You&apos;ve successfully logged in, but we couldn&apos;t find a
-          matching user account for you in our database. ({props.userEmail})
+          matching user account for you in our database. (
+          {props.userEmail
+            ?.split("_")
+            .slice(1, props.userEmail?.split("_").length)
+            .join()}
+          ){/* Removes prefixed idp provider that amplify adds */}
         </Text>
         <Text>
           This is likely because your user directory settings are misconfigured.

--- a/web/src/utils/context/userContext.tsx
+++ b/web/src/utils/context/userContext.tsx
@@ -41,6 +41,7 @@ const UserProvider: React.FC<Props> = ({ children }) => {
     // await Auth.currentSession();
 
     const me = await getMe();
+    console.log(me);
     if (me != null) {
       setUser(me.user);
       setIsAdmin(me.isAdmin);
@@ -57,8 +58,8 @@ const UserProvider: React.FC<Props> = ({ children }) => {
       case "cognitoHostedUI":
       case "signOut":
         setUser(undefined);
-        setLoading(false);
-        setamplifyLoggedIn(false);
+        //setLoading(false);
+        //setamplifyLoggedIn(false);
         break;
       case "signIn_failure":
 
@@ -130,10 +131,14 @@ const UserProvider: React.FC<Props> = ({ children }) => {
       </Center>
     );
   }
+  console.log(amplifyLoggedIn, user, loading);
   if (amplifyLoggedIn && user === undefined && !loading) {
     return (
       <Center h="100vh">
-        <NoUser userEmail={amplifyUser.username} initiateAuth={initiateAuth} />
+        <NoUser
+          userEmail={amplifyUser.username}
+          initiateSignOut={initiateSignOut}
+        />
       </Center>
     );
   }

--- a/web/src/utils/context/userContext.tsx
+++ b/web/src/utils/context/userContext.tsx
@@ -58,8 +58,7 @@ const UserProvider: React.FC<Props> = ({ children }) => {
       case "cognitoHostedUI":
       case "signOut":
         setUser(undefined);
-        //setLoading(false);
-        //setamplifyLoggedIn(false);
+
         break;
       case "signIn_failure":
 
@@ -131,7 +130,6 @@ const UserProvider: React.FC<Props> = ({ children }) => {
       </Center>
     );
   }
-  console.log(amplifyLoggedIn, user, loading);
   if (amplifyLoggedIn && user === undefined && !loading) {
     return (
       <Center h="100vh">

--- a/web/src/utils/context/userContext.tsx
+++ b/web/src/utils/context/userContext.tsx
@@ -40,12 +40,11 @@ const UserProvider: React.FC<Props> = ({ children }) => {
 
     // await Auth.currentSession();
 
-    const me = await getMe().then((user) => {
-      if (user != null) {
-        setUser(user.user);
-        setIsAdmin(user.isAdmin);
-      }
-    });
+    const me = await getMe();
+    if (me != null) {
+      setUser(me.user);
+      setIsAdmin(me.isAdmin);
+    }
     console.debug({ msg: "getMe response", me });
   }
 

--- a/web/src/utils/context/userContext.tsx
+++ b/web/src/utils/context/userContext.tsx
@@ -34,7 +34,7 @@ const UserProvider: React.FC<Props> = ({ children }) => {
 
   async function getUser() {
     if (!initialized) {
-      console.log("userContext: not initialized, skipping getUser");
+      console.debug("userContext: not initialized, skipping getUser");
       return;
     }
 

--- a/web/src/utils/context/userContext.tsx
+++ b/web/src/utils/context/userContext.tsx
@@ -41,7 +41,6 @@ const UserProvider: React.FC<Props> = ({ children }) => {
     // await Auth.currentSession();
 
     const me = await getMe();
-    console.log(me);
     if (me != null) {
       setUser(me.user);
       setIsAdmin(me.isAdmin);

--- a/web/src/utils/context/userContext.tsx
+++ b/web/src/utils/context/userContext.tsx
@@ -55,12 +55,6 @@ const UserProvider: React.FC<Props> = ({ children }) => {
         setamplifyLoggedIn(true);
         setamplifyUser(data);
       case "cognitoHostedUI":
-        await getUser().then((out) => {
-          if (user !== undefined) {
-            //setLoading(false );
-          }
-        });
-        break;
       case "signOut":
         setUser(undefined);
         setLoading(false);


### PR DESCRIPTION
If the logging in user is not found in Granteds database previously would cause a infinite loop in the frontend.
This fix will display a helpful error page if this occurs