### PR TITLE
Add tag check to permission set list method

### DIFF
--- a/accesshandler/pkg/providers/aws/sso/errors.go
+++ b/accesshandler/pkg/providers/aws/sso/errors.go
@@ -12,6 +12,16 @@ func (e *PermissionSetNotFoundErr) Error() string {
 	return fmt.Sprintf("permission set %s was not found or you don't have access to it", e.PermissionSet)
 }
 
+type PermissionSetNotManagedByGrantedError struct {
+	PermissionSet string
+	// the underlying AWS error
+	AWSErr error
+}
+
+func (e *PermissionSetNotManagedByGrantedError) Error() string {
+	return fmt.Sprintf("permission set %s is not tagged with 'commonfate.io/managed-by-granted' and cannot be accessed by this provider", e.PermissionSet)
+}
+
 type UserNotFoundError struct {
 	Email string
 }

--- a/accesshandler/pkg/providers/aws/sso/options.go
+++ b/accesshandler/pkg/providers/aws/sso/options.go
@@ -95,7 +95,7 @@ func (p *Provider) checkPermissionSetIsTagged(ctx context.Context, permissionSet
 		nextToken = tags.NextToken
 		hasMore = nextToken != nil
 		for _, tag := range tags.Tags {
-			if aws.ToString(tag.Key) == "commonfate.io/permission-set" {
+			if aws.ToString(tag.Key) == "commonfate.io/managed-by-granted" {
 				return true, nil
 			}
 		}

--- a/accesshandler/pkg/providers/aws/sso/options.go
+++ b/accesshandler/pkg/providers/aws/sso/options.go
@@ -20,26 +20,40 @@ func (p *Provider) Options(ctx context.Context, arg string) ([]types.Option, err
 		opts := []types.Option{}
 		hasMore := true
 		var nextToken *string
+
 		for hasMore {
 			o, err := p.client.ListPermissionSets(ctx, &ssoadmin.ListPermissionSetsInput{
 				InstanceArn: aws.String(p.instanceARN.Get()),
 				NextToken:   nextToken,
 			})
+
 			if err != nil {
 				return nil, err
 			}
 			nextToken = o.NextToken
 			hasMore = nextToken != nil
+
 			for _, arn := range o.PermissionSets {
+				// the user should exist in AWS SSO.
+				arnCopy := arn
+
 				po, err := p.client.DescribePermissionSet(ctx, &ssoadmin.DescribePermissionSetInput{
-					InstanceArn: aws.String(p.instanceARN.Get()), PermissionSetArn: aws.String(arn),
+					InstanceArn: aws.String(p.instanceARN.Get()), PermissionSetArn: aws.String(arnCopy),
 				})
 				if err != nil {
 					return nil, err
 				}
-				opts = append(opts, types.Option{Label: *po.PermissionSet.Name, Value: arn})
+				hasTag, err := p.checkPermissionSetIsTagged(ctx, arnCopy)
+				if err != nil {
+					return nil, err
+				}
+				if hasTag {
+					opts = append(opts, types.Option{Label: *po.PermissionSet.Name, Value: arnCopy})
+				}
+
 			}
 		}
+
 		return opts, nil
 	case "accountId":
 		log := zap.S().With("arg", arg)
@@ -65,4 +79,26 @@ func (p *Provider) Options(ctx context.Context, arg string) ([]types.Option, err
 
 	return nil, &providers.InvalidArgumentError{Arg: arg}
 
+}
+
+func (p *Provider) checkPermissionSetIsTagged(ctx context.Context, permissionSetARN string) (bool, error) {
+	hasMore := true
+	var nextToken *string
+	for hasMore {
+		tags, err := p.client.ListTagsForResource(ctx, &ssoadmin.ListTagsForResourceInput{
+			InstanceArn: aws.String(p.instanceARN.Get()),
+			ResourceArn: aws.String(permissionSetARN),
+		})
+		if err != nil {
+			return false, err
+		}
+		nextToken = tags.NextToken
+		hasMore = nextToken != nil
+		for _, tag := range tags.Tags {
+			if aws.ToString(tag.Key) == "commonfate.io/permission-set" {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }

--- a/accesshandler/pkg/providers/aws/sso/options.go
+++ b/accesshandler/pkg/providers/aws/sso/options.go
@@ -43,7 +43,7 @@ func (p *Provider) Options(ctx context.Context, arg string) ([]types.Option, err
 				if err != nil {
 					return nil, err
 				}
-				hasTag, err := p.checkPermissionSetIsTagged(ctx, arnCopy)
+				hasTag, err := p.checkPermissionSetIsManagedByGranted(ctx, arnCopy)
 				if err != nil {
 					return nil, err
 				}
@@ -81,7 +81,8 @@ func (p *Provider) Options(ctx context.Context, arg string) ([]types.Option, err
 
 }
 
-func (p *Provider) checkPermissionSetIsTagged(ctx context.Context, permissionSetARN string) (bool, error) {
+// checkPermissionSetIsManagedByGranted checks whether the permission set has the "commonfate.io/managed-by-granted" tag
+func (p *Provider) checkPermissionSetIsManagedByGranted(ctx context.Context, permissionSetARN string) (bool, error) {
 	hasMore := true
 	var nextToken *string
 	for hasMore {


### PR DESCRIPTION
This PR fixes a UX issue by introducing a resource tag check for th epermission sets.
In AWS there seems to be no way via the API to determine if a permission set belongs to the delegated account or not. Therefor we found the most suitable way to limit the permission set results is to have admins add a specific tag to the permission sets when they create them.

We will add this into our docs for SSO setup.

I have chosen a generic tag name `commonfate.io/permission-set` We should probably put some more though into this tag so that we can use it consistently for other resources in the future should we need to.

For example, permission sets generated by the access handler or other resources managed by granted