### PR TITLE
gdeploy: allow "-y" to be used as confirmation

### DIFF
--- a/cmd/gdeploy/commands/backup/backup.go
+++ b/cmd/gdeploy/commands/backup/backup.go
@@ -16,7 +16,7 @@ var Command = cli.Command{
 	Name:        "backup",
 	Description: "Backup Granted Approvals",
 	Flags: []cli.Flag{
-		&cli.BoolFlag{Name: "confirm", Usage: "If provided, will automatically deploy without asking for confirmation"},
+		&cli.BoolFlag{Name: "confirm", Aliases: []string{"y"}, Usage: "If provided, will automatically continue without asking for confirmation"},
 	},
 	Subcommands: []*cli.Command{&BackupStatus},
 	Action: func(c *cli.Context) error {

--- a/cmd/gdeploy/commands/create.go
+++ b/cmd/gdeploy/commands/create.go
@@ -13,7 +13,7 @@ var CreateCommand = cli.Command{
 	Usage:       "Create a new Granted Approvals deployment by deploying CloudFormation",
 	Description: "Create a new Granted Approvals deployment based on a deployment configuration file (granted-deployment.yml by default). Deploys resources to AWS using CloudFormation.",
 	Flags: []cli.Flag{
-		&cli.BoolFlag{Name: "confirm", Usage: "If provided, will automatically deploy without asking for confirmation"},
+		&cli.BoolFlag{Name: "confirm", Aliases: []string{"y"}, Usage: "If provided, will automatically deploy without asking for confirmation"},
 	},
 	Action: func(c *cli.Context) error {
 		ctx := c.Context

--- a/cmd/gdeploy/commands/restore/restore.go
+++ b/cmd/gdeploy/commands/restore/restore.go
@@ -15,7 +15,7 @@ var Command = cli.Command{
 	Name:        "restore",
 	Description: "Restore active Granted Approvals table from an existing backup",
 	Flags: []cli.Flag{
-		&cli.BoolFlag{Name: "confirm", Usage: "If provided, will automatically deploy without asking for confirmation"},
+		&cli.BoolFlag{Name: "confirm", Aliases: []string{"y"}, Usage: "If provided, will automatically continue without asking for confirmation"},
 		&cli.StringFlag{Name: "arn", Usage: "The ARN of the backup to restore"},
 		&cli.StringFlag{Name: "table-name", Usage: "The name of a new table to restore this backup to"},
 	},

--- a/cmd/gdeploy/commands/update.go
+++ b/cmd/gdeploy/commands/update.go
@@ -13,7 +13,7 @@ var UpdateCommand = cli.Command{
 	Usage:       "Update a Granted Approvals deployment CloudFormation stack",
 	Description: "Update Granted Approvals deployment based on a deployment configuration file (granted-deployment.yml by default). Deploys resources to AWS using CloudFormation.",
 	Flags: []cli.Flag{
-		&cli.BoolFlag{Name: "confirm", Usage: "If provided, will automatically deploy without asking for confirmation"},
+		&cli.BoolFlag{Name: "confirm", Aliases: []string{"y"}, Usage: "If provided, will automatically deploy without asking for confirmation"},
 	},
 	Action: func(c *cli.Context) error {
 		ctx := c.Context


### PR DESCRIPTION
adds a `-y` alias to the `--confirm` argument.