### PR TITLE
Improve the provider preview component

### DIFF
--- a/web/src/components/forms/access-rule/components/ProviderPreview.tsx
+++ b/web/src/components/forms/access-rule/components/ProviderPreview.tsx
@@ -44,12 +44,12 @@ export const ProviderPreview: React.FC<{ target: AccessRuleTarget }> = ({
       return (
         <WrapItem>
           <Tooltip label={value}>
-            <Box
+            <Flex
               textStyle={"Body/Small"}
               rounded="full"
               bg="neutrals.300"
               py={1}
-              px={2}
+              px={4}
             >
               {label}{" "}
               <IconButton
@@ -59,7 +59,7 @@ export const ProviderPreview: React.FC<{ target: AccessRuleTarget }> = ({
                 onClick={onCopy}
                 aria-label={"Copy"}
               />
-            </Box>
+            </Flex>
           </Tooltip>
         </WrapItem>
       );

--- a/web/src/components/forms/access-rule/components/ProviderPreview.tsx
+++ b/web/src/components/forms/access-rule/components/ProviderPreview.tsx
@@ -1,6 +1,20 @@
-import { Box, Flex, HStack, Spacer, Text, VStack } from "@chakra-ui/react";
+import { CheckIcon, CopyIcon } from "@chakra-ui/icons";
+import {
+  Box,
+  Flex,
+  HStack,
+  IconButton,
+  Spacer,
+  Tag,
+  Text,
+  Tooltip,
+  useClipboard,
+  VStack,
+  Wrap,
+  WrapItem,
+} from "@chakra-ui/react";
 import Form, { FieldProps } from "@rjsf/core";
-import React, { useEffect, useState } from "react";
+import React from "react";
 import {
   useGetProviderArgs,
   useListProviderArgOptions,
@@ -22,19 +36,70 @@ export const ProviderPreview: React.FC<{ target: AccessRuleTarget }> = ({
   }
   const ProviderPreviewWithDisplay: React.FC<FieldProps> = (props) => {
     const { data } = useListProviderArgOptions(target.provider.id, props.name);
-
-    const value = target.with[props.name];
-    const [label, setLabel] = useState<string>();
-    useEffect(() => {
-      const l = data?.options.find((d) => d.value === value);
-      setLabel(l?.label ?? "");
-    }, [data, value]);
+    const CopyableOption: React.FC<{ label: string; value: string }> = ({
+      label,
+      value,
+    }) => {
+      const { hasCopied, onCopy } = useClipboard(value);
+      return (
+        <WrapItem>
+          <Tooltip label={value}>
+            <Box
+              textStyle={"Body/Small"}
+              rounded="full"
+              bg="neutrals.300"
+              py={1}
+              px={2}
+            >
+              {label}{" "}
+              <IconButton
+                variant="ghost"
+                h="20px"
+                icon={hasCopied ? <CheckIcon /> : <CopyIcon />}
+                onClick={onCopy}
+                aria-label={"Copy"}
+              />
+            </Box>
+          </Tooltip>
+        </WrapItem>
+      );
+    };
+    if (props.name in target.with) {
+      const value = target.with[props.name];
+      return (
+        <VStack w="100%" align={"flex-start"} spacing={0}>
+          <Text>{props.schema.title}:</Text>
+          <CopyableOption
+            label={data?.options.find((d) => d.value === value)?.label ?? ""}
+            value={value}
+          />
+        </VStack>
+      );
+    }
+    if (props.name in target.withSelectable) {
+      const value = target.withSelectable[props.name];
+      return (
+        <VStack w="100%" align={"flex-start"} spacing={0}>
+          <Text>{props.schema.title}</Text>
+          <Wrap>
+            {value.map((opt) => {
+              return (
+                <CopyableOption
+                  key={"cp-" + opt}
+                  label={
+                    data?.options.find((d) => d.value === opt)?.label ?? ""
+                  }
+                  value={opt}
+                />
+              );
+            })}
+          </Wrap>
+        </VStack>
+      );
+    }
     return (
       <VStack w="100%" align={"flex-start"} spacing={0}>
-        <Text>
-          {props.schema.title}: {label}
-        </Text>
-        <Text textStyle={"Body/SmallBold"}>{value}</Text>
+        <Text>{props.schema.title}:</Text>
       </VStack>
     );
   };

--- a/web/src/components/forms/access-rule/components/Select.tsx
+++ b/web/src/components/forms/access-rule/components/Select.tsx
@@ -110,12 +110,17 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
                   ...provided,
                   borderRadius: "20px",
                   background: colors.neutrals[100],
+                  // @TODO Hack: I couldn't work out why the layout was overflowing the step container so I added this as a workaround to fix it
+                  // this doesn't work on small screens like mobile
+                  maxWidth: "400px",
                 };
               },
               container: (provided, state) => {
                 return {
                   ...provided,
-                  minWidth: "100%",
+                  // @TODO Hack: I couldn't work out why the layout was overflowing the step container so I added this as a workaround to fix it
+                  // this doesn't work on small screens like mobile
+                  minWidth: "calc(-20px + 100%)",
                 };
               },
             }}

--- a/web/src/components/forms/access-rule/steps/Provider.tsx
+++ b/web/src/components/forms/access-rule/steps/Provider.tsx
@@ -61,13 +61,13 @@ export const ProviderStep: React.FC = () => {
     if (!target || !provider || !target?.with) {
       return null;
     }
+
     return (
       <ProviderPreview
         target={{
           provider: provider,
+          withSelectable: target.with,
           with: {},
-          withSelectable: {},
-          // with: target.with,
         }}
       />
     );


### PR DESCRIPTION
Fixes #199 

includes a bit of a CSS hack to stop overflowing because I couldn't find the exact component causing the overflow when provider option label was big

<img width="784" alt="image" src="https://user-images.githubusercontent.com/14214200/187828814-af4b9e3c-a0a6-474b-902e-487955058285.png">
<img width="786" alt="image" src="https://user-images.githubusercontent.com/14214200/187828839-49dfbfae-ab51-406d-a327-bb454ec47364.png">
