### PR TITLE
Setup provider api errors

### DIFF
--- a/accesshandler/pkg/api/validate_setup.go
+++ b/accesshandler/pkg/api/validate_setup.go
@@ -7,6 +7,7 @@ import (
 	"github.com/common-fate/apikit/apio"
 	"github.com/common-fate/apikit/logger"
 	"github.com/common-fate/granted-approvals/accesshandler/pkg/config"
+	"github.com/common-fate/granted-approvals/accesshandler/pkg/diagnostics"
 	"github.com/common-fate/granted-approvals/accesshandler/pkg/providerregistry"
 	"github.com/common-fate/granted-approvals/accesshandler/pkg/providers"
 	"github.com/common-fate/granted-approvals/accesshandler/pkg/types"
@@ -35,54 +36,62 @@ func (a *API) ValidateSetup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	p := rp.Provider
-	err = config.SetupProvider(ctx, p, &gconfig.MapLoader{Values: b.With})
-	if err != nil {
-		// this shouldn't happen, so return an opaque response to the client and log the error ourselves.
-		logger.Get(ctx).Error("error setting up provider", zap.Error(err))
-		apio.ErrorString(ctx, w, "error setting up provider", http.StatusBadRequest)
-		return
-	}
-
 	cv, ok := p.(providers.ConfigValidator)
 	if !ok {
 		apio.ErrorString(ctx, w, "provider does not implement config validation", http.StatusBadRequest)
 		return
 	}
 	validations := cv.ValidateConfig()
-
 	res := types.ValidateResponse{}
 	var mu sync.Mutex
+	handleResults := func(key string, value providers.ConfigValidationStep, logs diagnostics.Logs) {
+		mu.Lock()
+		defer mu.Unlock()
 
+		result := types.ProviderConfigValidation{
+			Id:              key,
+			Name:            value.Name,
+			FieldsValidated: value.FieldsValidated,
+		}
+
+		if logs.HasSucceeded() {
+			result.Status = types.SUCCESS
+		} else {
+			result.Status = types.ERROR
+		}
+
+		for _, l := range logs {
+			result.Logs = append(result.Logs, types.Log{
+				Level: types.LogLevel(l.Level),
+				Msg:   l.Msg,
+			})
+		}
+
+		res.Validations = append(res.Validations, result)
+	}
+
+	// We will likely encounter an error while initialising the provider internals if some of the values are completely wrong.
+	// for example a role ARN being invalid will fail when testing assumed role credentials.
+	err = config.SetupProvider(ctx, p, &gconfig.MapLoader{Values: b.With})
+	if err != nil {
+		logger.Get(ctx).Error("error setting up provider", zap.Error(err))
+		// We set the initialisation error on all tests and return to the client
+		// because it's difficult for us know know which field exactly caused the error as our init methods on providers are mostly out of our control
+		for key, val := range validations {
+			handleResults(key, val, diagnostics.Error(err))
+		}
+		apio.JSON(ctx, w, res, http.StatusOK)
+		return
+	}
+
+	// if there were no initialisation errors, we can run the validations!
 	g, gctx := errgroup.WithContext(ctx)
 	for key, val := range validations {
 		k := key
 		v := val
-
 		g.Go(func() error {
 			logs := v.Run(gctx)
-			mu.Lock()
-			defer mu.Unlock()
-
-			result := types.ProviderConfigValidation{
-				Id:              k,
-				Name:            v.Name,
-				FieldsValidated: v.FieldsValidated,
-			}
-
-			if logs.HasSucceeded() {
-				result.Status = types.SUCCESS
-			} else {
-				result.Status = types.ERROR
-			}
-
-			for _, l := range logs {
-				result.Logs = append(result.Logs, types.Log{
-					Level: types.LogLevel(l.Level),
-					Msg:   l.Msg,
-				})
-			}
-
-			res.Validations = append(res.Validations, result)
+			handleResults(k, v, logs)
 			return nil
 		})
 	}

--- a/accesshandler/pkg/api/validate_setup.go
+++ b/accesshandler/pkg/api/validate_setup.go
@@ -31,6 +31,7 @@ func (a *API) ValidateSetup(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		logger.Get(ctx).Error("error looking up provider", zap.Error(err))
 		apio.ErrorString(ctx, w, "error looking up provider", http.StatusBadRequest)
+		return
 	}
 
 	p := rp.Provider
@@ -39,6 +40,7 @@ func (a *API) ValidateSetup(w http.ResponseWriter, r *http.Request) {
 		// this shouldn't happen, so return an opaque response to the client and log the error ourselves.
 		logger.Get(ctx).Error("error setting up provider", zap.Error(err))
 		apio.ErrorString(ctx, w, "error setting up provider", http.StatusBadRequest)
+		return
 	}
 
 	cv, ok := p.(providers.ConfigValidator)

--- a/pkg/api/request_admin.go
+++ b/pkg/api/request_admin.go
@@ -12,7 +12,7 @@ import (
 	"github.com/common-fate/granted-approvals/pkg/types"
 )
 
-//"/api/v1/admin/requests"
+// "/api/v1/admin/requests"
 func (a *API) AdminListRequests(w http.ResponseWriter, r *http.Request, params types.AdminListRequestsParams) {
 	ctx := r.Context()
 
@@ -34,6 +34,7 @@ func (a *API) AdminListRequests(w http.ResponseWriter, r *http.Request, params t
 		}
 		if err != nil {
 			apio.Error(ctx, w, err)
+			return
 		}
 		if qR.NextPage != "" {
 			next = &qR.NextPage

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/common-fate/apikit/logger"
 	"github.com/common-fate/apikit/openapi"
+	"github.com/common-fate/granted-approvals/internal/build"
 	"github.com/common-fate/granted-approvals/pkg/auth"
 
 	"github.com/go-chi/chi/v5"
@@ -15,11 +16,15 @@ import (
 
 func (c *Server) Handler() http.Handler {
 	r := chi.NewRouter()
-
+	timeout := 30 * time.Second
+	// use a long timeout in dev for debugging
+	if build.Version == "dev" {
+		timeout = 10 * time.Minute
+	}
 	r.Use(c.requestIDMiddleware)
 	r.Use(chiMiddleware.RealIP)
 	r.Use(chiMiddleware.Recoverer)
-	r.Use(chiMiddleware.Timeout(30 * time.Second))
+	r.Use(chiMiddleware.Timeout(timeout))
 	r.Use(logger.Middleware(c.log.Desugar()))
 	r.Use(sentryMiddleware)
 	r.Use(cors.Handler(cors.Options{

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/common-fate/apikit/logger"
 	"github.com/common-fate/apikit/openapi"
-	"github.com/common-fate/granted-approvals/internal/build"
 	"github.com/common-fate/granted-approvals/pkg/auth"
 
 	"github.com/go-chi/chi/v5"
@@ -16,15 +15,10 @@ import (
 
 func (c *Server) Handler() http.Handler {
 	r := chi.NewRouter()
-	timeout := 30 * time.Second
-	// use a long timeout in dev for debugging
-	if build.Version == "dev" {
-		timeout = 10 * time.Minute
-	}
 	r.Use(c.requestIDMiddleware)
 	r.Use(chiMiddleware.RealIP)
 	r.Use(chiMiddleware.Recoverer)
-	r.Use(chiMiddleware.Timeout(timeout))
+	r.Use(chiMiddleware.Timeout(30 * time.Second))
 	r.Use(logger.Middleware(c.log.Desugar()))
 	r.Use(sentryMiddleware)
 	r.Use(cors.Handler(cors.Options{

--- a/pkg/service/psetupsvc/complete_step.go
+++ b/pkg/service/psetupsvc/complete_step.go
@@ -65,6 +65,12 @@ func (s *Service) CompleteStep(ctx context.Context, setupID string, stepIndex in
 		cfg = configer.Config()
 	}
 
+	// load the current values into this config
+	err = cfg.Load(ctx, &gconfig.MapLoader{Values: setup.ConfigValues})
+	if err != nil {
+		return nil, err
+	}
+
 	// verify that all fields actually correspond to the provider
 	for key, value := range body.ConfigValues {
 		f, err := cfg.FindFieldByKey(key)

--- a/web/src/pages/admin/providers/setup/[id]/index.tsx
+++ b/web/src/pages/admin/providers/setup/[id]/index.tsx
@@ -75,7 +75,6 @@ const Page = () => {
   const [accordionIndex, setAccordionIndex] = useState([0]);
   const { data, mutate } = useGetProvidersetup(id);
   const { data: instructions } = useGetProvidersetupInstructions(id);
-  console.log({ data });
   // used to look up extra details like the name
   const registeredProvider = registeredProviders.find(
     (rp) => rp.type === data?.type
@@ -436,7 +435,6 @@ const StepDisplay: React.FC<StepDisplayProps> = ({
   const { control, handleSubmit } = useForm<Record<string, string>>({
     defaultValues: configValues,
   });
-  console.log({ step: step, configValues });
   const onSubmit = async (data: Record<string, string>) => {
     const filteredData: Record<string, string> = {};
     step.configFields.forEach((f) => {

--- a/web/src/pages/admin/providers/setup/[id]/index.tsx
+++ b/web/src/pages/admin/providers/setup/[id]/index.tsx
@@ -75,7 +75,7 @@ const Page = () => {
   const [accordionIndex, setAccordionIndex] = useState([0]);
   const { data, mutate } = useGetProvidersetup(id);
   const { data: instructions } = useGetProvidersetupInstructions(id);
-
+  console.log({ data });
   // used to look up extra details like the name
   const registeredProvider = registeredProviders.find(
     (rp) => rp.type === data?.type
@@ -436,13 +436,19 @@ const StepDisplay: React.FC<StepDisplayProps> = ({
   const { control, handleSubmit } = useForm<Record<string, string>>({
     defaultValues: configValues,
   });
-
+  console.log({ step: step, configValues });
   const onSubmit = async (data: Record<string, string>) => {
+    const filteredData: Record<string, string> = {};
+    step.configFields.forEach((f) => {
+      filteredData[f.id] = data[f.id];
+    });
+    console.log({ datas: data, filteredData });
     setLoading(true);
     const res = await submitProvidersetupStep(setupId, index, {
       complete: true,
-      configValues: data,
+      configValues: filteredData,
     });
+
     await mutate(res);
     setLoading(false);
     onComplete?.();

--- a/web/src/pages/admin/providers/setup/[id]/index.tsx
+++ b/web/src/pages/admin/providers/setup/[id]/index.tsx
@@ -442,7 +442,7 @@ const StepDisplay: React.FC<StepDisplayProps> = ({
     step.configFields.forEach((f) => {
       filteredData[f.id] = data[f.id];
     });
-    console.log({ datas: data, filteredData });
+    
     setLoading(true);
     const res = await submitProvidersetupStep(setupId, index, {
       complete: true,


### PR DESCRIPTION
This PR fixes a bug where config values were being lost. the issue was caused by a few FE and BE issues in combination.

This also addresses some apoi.Errror responses where the retrun statement was missing, leading to panics

Also addresses the handling of provider.Init failing during validation.
When the provider init fails, for example due to a role arn being misconfigured, the failure will now be reported as the result for all tests, before it would not report back to the fe client at all!