### PR TITLE
clio: print to stderr rather than stdout

### DIFF
--- a/pkg/clio/log.go
+++ b/pkg/clio/log.go
@@ -2,39 +2,47 @@
 package clio
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
 	"github.com/fatih/color"
 )
 
+// Log prints to stdout.
 func Log(format string, a ...interface{}) {
 	color.White(format, a...)
 }
 
+// Info prints to stderr with an [i] indicator.
 func Info(format string, a ...interface{}) {
 	format = "[i] " + format
-	color.White(format, a...)
+	fmt.Fprintln(color.Error, color.WhiteString(format, a...))
 }
 
+// Success prints to stderr with a [✔] indicator.
 func Success(format string, a ...interface{}) {
 	format = "[✔] " + format
-	color.Green(format, a...)
+	fmt.Fprintln(color.Error, color.GreenString(format, a...))
 }
 
+// Error prints to stderr with a [✘] indicator.
 func Error(format string, a ...interface{}) {
 	format = "[✘] " + format
-	color.Red(format, a...)
+	fmt.Fprintln(color.Error, color.RedString(format, a...))
 }
 
+// Warn prints to stderr with a [!] indicator.
 func Warn(format string, a ...interface{}) {
 	format = "[!] " + format
-	color.Yellow(format, a...)
+	fmt.Fprintln(color.Error, color.YellowString(format, a...))
 }
 
+// Warn prints to stderr with a [DEBUG] indicator
+// if the GRANTED_LOG environment variable is set to 'debug'.
 func Debug(format string, a ...interface{}) {
 	if strings.ToLower(os.Getenv("GRANTED_LOG")) == "debug" {
 		format = "[DEBUG] " + format
-		color.HiBlack(format, a...)
+		fmt.Fprintln(color.Error, color.HiBlackString(format, a...))
 	}
 }


### PR DESCRIPTION
Prints user friendly logging messages to stderr rather than stdout.

The specific use case here is that we have some commands which are more 'unix-ey' and designed to be piped to other commands. (we don't have many of these yet, but I expect we'll have more in future).

For example, `gdeploy dashboard url` prints the dashboard URL of a deployment, which can be used with `pbcopy` to conveniently copy the dashboard URL to the clipboard:

```bash
gdeploy dashboard url | pbcopy
```

However, warning messages emitted by `gdeploy` pollute this output! As an example:

```
❯ gdeploy dashboard url
[!] Ignoring version mismatch between gdeploy CLI (dev) and deployment release version (v0.3.2)
https://abcdef123456.cloudfront.net
```

Now, when `gdeploy dashboard url | pbcopy` is run, we get the warning message as well as the URL we want. Gross!

This PR fixes this by printing diagnostics to `stderr` rather than `stdout`.