### PR TITLE
add aliases for top-level gdeploy commands

### DIFF
--- a/cmd/gdeploy/commands/logs/logs.go
+++ b/cmd/gdeploy/commands/logs/logs.go
@@ -4,6 +4,7 @@ import "github.com/urfave/cli/v2"
 
 var Command = cli.Command{
 	Name:        "logs",
+	Aliases:     []string{"log"},
 	Description: "View recent application logs from Cloudwatch or stream them in real time",
 	Usage:       "View recent application logs from Cloudwatch or stream them in real time",
 	Action:      cli.ShowSubcommandHelp,

--- a/cmd/gdeploy/commands/notifications/notifications.go
+++ b/cmd/gdeploy/commands/notifications/notifications.go
@@ -7,6 +7,7 @@ import (
 
 var Command = cli.Command{
 	Name:        "notifications",
+	Aliases:     []string{"notification"},
 	Description: "Manage your notification channels like Slack",
 	Usage:       "Manage your notification channels like Slack",
 	Action:      cli.ShowSubcommandHelp,

--- a/cmd/gdeploy/commands/provider/provider.go
+++ b/cmd/gdeploy/commands/provider/provider.go
@@ -4,6 +4,7 @@ import "github.com/urfave/cli/v2"
 
 var Command = cli.Command{
 	Name:        "providers",
+	Aliases:     []string{"provider"},
 	Description: "Manage your Access Providers",
 	Usage:       "Manage your Access Providers",
 	Subcommands: []*cli.Command{


### PR DESCRIPTION
helps retain backwards compatibility and avoid a breaking change with the 'providers' command