### PR TITLE
Improve aws sso provider setup instructions

### DIFF
--- a/accesshandler/pkg/providers/aws/sso-v2/setup/1.md
+++ b/accesshandler/pkg/providers/aws/sso-v2/setup/1.md
@@ -4,52 +4,81 @@ configFields:
   - ssoRoleArn
 ---
 
-Create an IAM role in the AWS console:
+The AWS SSO provider requires permissions to manage your SSO instance.
 
-```json
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "sso:CreateAccountAssignment",
-        "sso:DescribeAccountAssignmentDeletionStatus",
-        "sso:DescribeAccountAssignmentCreationStatus",
-        "sso:DescribePermissionSet",
-        "sso:DeleteAccountAssignment",
-        "sso:ListPermissionSets",
-        "sso:ListTagsForResource",
-        "sso:ListAccountAssignments",
-        "organizations:ListAccounts",
-        "organizations:DescribeAccount",
-        "organizations:DescribeOrganization",
-        "iam:GetSAMLProvider",
-        "iam:GetRole",
-        "iam:ListAttachedRolePolicies",
-        "iam:ListRolePolicies",
-        "identitystore:ListUsers"
-      ],
-      "Resource": "*",
-      "Effect": "Allow"
-    }
-  ]
-}
+The following instructions will help you to setup the required IAM Role with a trust relationship that allows only the Granted Approvals Access Handler to assume the role.
+
+This role should be created in your AWS management account, the account where AWS SSO is configured and your AWS Organization is managed.
+
+Copy the following YAML and save it as 'granted-access-handler-sso-role.yml'.
+
+We recommend saving this alongside your granted-deployment.yml file in source control.
+
+```yaml
+Resources:
+  GrantedAccessHandlerSSORole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              AWS: "{{ .AccessHandlerExecutionRoleARN }}"
+        Version: "2012-10-17"
+      Description: This role grants management access to AWS SSO for the Granted Access Handler.
+      Policies:
+        - PolicyDocument:
+            Statement:
+              - Action:
+                  - sso:CreateAccountAssignment
+                  - sso:DescribeAccountAssignmentDeletionStatus
+                  - sso:DescribeAccountAssignmentCreationStatus
+                  - sso:DescribePermissionSet
+                  - sso:DeleteAccountAssignment
+                  - sso:ListPermissionSets
+                  - sso:ListTagsForResource
+                  - sso:ListAccountAssignments
+                  - organizations:ListAccounts
+                  - organizations:DescribeAccount
+                  - organizations:DescribeOrganization
+                  - iam:GetSAMLProvider
+                  - iam:GetRole
+                  - iam:ListAttachedRolePolicies
+                  - iam:ListRolePolicies
+                  - identitystore:ListUsers
+                Effect: Allow
+                Resource: "*"
+            Version: "2012-10-17"
+          PolicyName: AccessHandlerSSOPolicy
+Outputs:
+  RoleARN:
+    Value:
+      Fn::GetAtt:
+        - GrantedAccessHandlerSSORole
+        - Arn
 ```
 
-The IAM role should have a trust policy defined as follows:
+Open the AWS Console in your organisation's management account and click **Create stack** then select **with new resources (standard)** from the menu.
 
-```json
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "{{ .AccessHandlerExecutionRoleARN }}"
-      },
-      "Action": "sts:AssumeRole",
-      "Condition": {}
-    }
-  ]
-}
-```
+![](https://static.commonfate.io/providers/aws/sso/create-stack.png)
+
+Upload the template file
+
+![](https://static.commonfate.io/providers/aws/sso/create-stack-with-template.png)
+
+Name the stack 'Granted-Access-Handler-SSO-Role'
+
+![](https://static.commonfate.io/providers/aws/sso/specify-stack-details.png)
+
+Click **Next**
+
+Click **Next**
+
+Acknowledge the IAM role creation check box and click **Create Stack**
+
+![](https://static.commonfate.io/providers/aws/sso/accept-iam-prompt.png)
+
+Copy the **RoleARN** output from the stack and paste it in the **ssoRoleArn** config value on the right.
+
+![](https://static.commonfate.io/providers/aws/sso/role-output.png)

--- a/deploy/provider-stacks/.gitignore
+++ b/deploy/provider-stacks/.gitignore
@@ -1,0 +1,16 @@
+*.js
+!jest.config.js
+*.d.ts
+node_modules
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+synthout.txt
+lib/constructs/app-cdn.auth-handler.config.json

--- a/deploy/provider-stacks/.npmignore
+++ b/deploy/provider-stacks/.npmignore
@@ -1,0 +1,6 @@
+*.ts
+!*.d.ts
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/deploy/provider-stacks/.prettierrc
+++ b/deploy/provider-stacks/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "trailingComma": "es5",
+  "singleQuote": false,
+  "printWidth": 80,
+  "tabWidth": 2,
+  "quoteProps": "consistent"
+}

--- a/deploy/provider-stacks/bin/aws-sso-role.ts
+++ b/deploy/provider-stacks/bin/aws-sso-role.ts
@@ -1,0 +1,48 @@
+import { App, CfnOutput, Stack } from "aws-cdk-lib";
+import { Construct } from "constructs";
+import * as iam from "aws-cdk-lib/aws-iam";
+class AWSSSORoleStack extends Stack {
+  constructor(scope: Construct, id: string, props: any) {
+    super(scope, id, props);
+    const role = new iam.Role(this, "GrantedAccessHandlerSSO", {
+      assumedBy: new iam.ArnPrincipal(
+        "arn:aws:iam::12345678912:role/granted-approvals"
+      ),
+      description:
+        "This role grants management access to AWS SSO for the Granted Access Handler.",
+      inlinePolicies: {
+        AccessHandlerSSOPolicy: new iam.PolicyDocument({
+          statements: [
+            new iam.PolicyStatement({
+              actions: [
+                "sso:CreateAccountAssignment",
+                "sso:DescribeAccountAssignmentDeletionStatus",
+                "sso:DescribeAccountAssignmentCreationStatus",
+                "sso:DescribePermissionSet",
+                "sso:DeleteAccountAssignment",
+                "sso:ListPermissionSets",
+                "sso:ListTagsForResource",
+                "sso:ListAccountAssignments",
+                "organizations:ListAccounts",
+                "organizations:DescribeAccount",
+                "organizations:DescribeOrganization",
+                "iam:GetSAMLProvider",
+                "iam:GetRole",
+                "iam:ListAttachedRolePolicies",
+                "iam:ListRolePolicies",
+                "identitystore:ListUsers",
+              ],
+              resources: ["*"],
+            }),
+          ],
+        }),
+      },
+    });
+    new CfnOutput(this, "RoleARN", {
+      value: role.roleArn,
+    });
+  }
+}
+
+const app = new App();
+new AWSSSORoleStack(app, "AWSSSORoleStack", {});

--- a/deploy/provider-stacks/cdk.json
+++ b/deploy/provider-stacks/cdk.json
@@ -1,0 +1,4 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/aws-sso-role.ts",
+  "versionReporting": false
+}

--- a/deploy/provider-stacks/package.json
+++ b/deploy/provider-stacks/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "deploy",
+  "version": "0.1.0",
+  "bin": {
+    "deploy": "bin/deploy.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "publisher": "npx ts-node assetpublisher.ts",
+    "watch": "tsc -w",
+    "cdk": "cdk"
+  },
+  "devDependencies": {
+    "@aws-cdk/cloud-assembly-schema": "^2.29.1",
+    "@aws-cdk/cx-api": "^2.29.1",
+    "@types/jest": "^26.0.10",
+    "@types/node": "10.17.27",
+    "jest": "^26.4.2",
+    "ts-jest": "^26.2.0",
+    "ts-node": "^9.1.1",
+    "typescript": "~4.7.4"
+  },
+  "dependencies": {
+    "@aws-sdk/client-ssm": "^3.76.0",
+    "@types/aws-lambda": "^8.10.95",
+    "aws-cdk": "^2.20.0",
+    "aws-cdk-lib": "^2.20.0",
+    "aws-lambda": "^1.0.7",
+    "aws-sdk": "^2.1160.0",
+    "cdk-assets": "^2.29.0",
+    "cognito-at-edge": "^1.2.2",
+    "constructs": "^10.0.121",
+    "js-yaml": "^4.1.0"
+  }
+}

--- a/deploy/provider-stacks/tsconfig.json
+++ b/deploy/provider-stacks/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "commonjs",
+    "lib": ["es2018"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "resolveJsonModule": true,
+    "typeRoots": ["./node_modules/@types"]
+  },
+  "exclude": ["node_modules", "cdk.out"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,47 @@ importers:
       ts-node: 9.1.1_typescript@4.7.4
       typescript: 4.7.4
 
+  deploy/provider-stacks:
+    specifiers:
+      '@aws-cdk/cloud-assembly-schema': ^2.29.1
+      '@aws-cdk/cx-api': ^2.29.1
+      '@aws-sdk/client-ssm': ^3.76.0
+      '@types/aws-lambda': ^8.10.95
+      '@types/jest': ^26.0.10
+      '@types/node': 10.17.27
+      aws-cdk: ^2.20.0
+      aws-cdk-lib: ^2.20.0
+      aws-lambda: ^1.0.7
+      aws-sdk: ^2.1160.0
+      cdk-assets: ^2.29.0
+      cognito-at-edge: ^1.2.2
+      constructs: ^10.0.121
+      jest: ^26.4.2
+      js-yaml: ^4.1.0
+      ts-jest: ^26.2.0
+      ts-node: ^9.1.1
+      typescript: ~4.7.4
+    dependencies:
+      '@aws-sdk/client-ssm': 3.154.0
+      '@types/aws-lambda': 8.10.102
+      aws-cdk: 2.38.1
+      aws-cdk-lib: 2.38.1_constructs@10.1.84
+      aws-lambda: 1.0.7
+      aws-sdk: 2.1200.0
+      cdk-assets: 2.38.1
+      cognito-at-edge: 1.2.2
+      constructs: 10.1.84
+      js-yaml: 4.1.0
+    devDependencies:
+      '@aws-cdk/cloud-assembly-schema': 2.38.1
+      '@aws-cdk/cx-api': 2.38.1
+      '@types/jest': 26.0.24
+      '@types/node': 10.17.27
+      jest: 26.6.3_ts-node@9.1.1
+      ts-jest: 26.5.6_rnfpnlbz3wqspag7uftsmccrvy
+      ts-node: 9.1.1_typescript@4.7.4
+      typescript: 4.7.4
+
   web:
     specifiers:
       '@aws-amplify/api': ^4.0.42


### PR DESCRIPTION
Improve provider setup instructions by including cloudformation templates for aws sso role

I also included a small cdk stack I used to help generate the Cloudformation yaml