### PR TITLE
Render Inline code inside markdown in the same line

### DIFF
--- a/web/src/components/CodeInstruction.tsx
+++ b/web/src/components/CodeInstruction.tsx
@@ -36,11 +36,7 @@ export const CodeInstruction: React.FC<CodeProps> = (props) => {
           borderColor="neutrals.300"
           borderWidth="1px"
         >
-          <Text
-            color="neutrals.700"
-            paddingLeft={3}
-            whiteSpace="pre-wrap"
-          >
+          <Text color="neutrals.700" paddingLeft={3} whiteSpace="pre-wrap">
             {children}
 
             <IconButton
@@ -54,7 +50,7 @@ export const CodeInstruction: React.FC<CodeProps> = (props) => {
           </Text>
         </Code>
       </div>
-    )
+    );
   }
 
   return (

--- a/web/src/components/CodeInstruction.tsx
+++ b/web/src/components/CodeInstruction.tsx
@@ -26,9 +26,39 @@ export const CodeInstruction: React.FC<CodeProps> = (props) => {
   const { hasCopied, onCopy } = useClipboard(value);
 
   // if the code is inline should show in same line.
-  if(props?.inline){
+  if (props?.inline) {
     return (
-      <div style={{display: "inline"}}>
+      <div style={{ display: "inline" }}>
+        <Code
+          padding={0}
+          bg="white"
+          borderRadius="8px"
+          borderColor="neutrals.300"
+          borderWidth="1px"
+        >
+          <Text
+            color="neutrals.700"
+            paddingLeft={3}
+            whiteSpace="pre-wrap"
+          >
+            {children}
+
+            <IconButton
+              variant="ghost"
+              h="10px"
+              style={{ backgroundColor: "transparent" }}
+              icon={hasCopied ? <CheckIcon /> : <CopyIcon />}
+              onClick={onCopy}
+              aria-label={"Copy"}
+            />
+          </Text>
+        </Code>
+      </div>
+    )
+  }
+
+  return (
+    <Stack>
       <Code
         padding={0}
         bg="white"
@@ -36,61 +66,31 @@ export const CodeInstruction: React.FC<CodeProps> = (props) => {
         borderColor="neutrals.300"
         borderWidth="1px"
       >
-        <Text
-          color="neutrals.700"
-          paddingLeft={3}
-          whiteSpace="pre-wrap"
-        > 
-          {children}
-
+        <Flex
+          borderColor="neutrals.300"
+          borderBottomWidth="1px"
+          py="8px"
+          px="16px"
+          minH="36px"
+        >
+          <Spacer />
           <IconButton
             variant="ghost"
-            h="10px"
-            style={{backgroundColor: "transparent"}}
+            h="20px"
             icon={hasCopied ? <CheckIcon /> : <CopyIcon />}
             onClick={onCopy}
             aria-label={"Copy"}
           />
-         </Text>
+        </Flex>
+        <Text
+          overflowX="auto"
+          color="neutrals.700"
+          padding={4}
+          whiteSpace="pre-wrap"
+        >
+          {children}
+        </Text>
       </Code>
-      </div>
-    )
-  }
-
-  return (
-    <Stack>
-    <Code
-      padding={0}
-      bg="white"
-      borderRadius="8px"
-      borderColor="neutrals.300"
-      borderWidth="1px"
-    >
-      <Flex
-        borderColor="neutrals.300"
-        borderBottomWidth="1px"
-        py="8px"
-        px="16px"
-        minH="36px"
-      >
-        <Spacer />
-        <IconButton
-          variant="ghost"
-          h="20px"
-          icon={hasCopied ? <CheckIcon /> : <CopyIcon />}
-          onClick={onCopy}
-          aria-label={"Copy"}
-        />
-      </Flex>
-      <Text
-        overflowX="auto"
-        color="neutrals.700"
-        padding={4}
-        whiteSpace="pre-wrap"
-      >
-        {children}
-      </Text>
-    </Code>
-  </Stack>
+    </Stack>
   );
 };

--- a/web/src/components/CodeInstruction.tsx
+++ b/web/src/components/CodeInstruction.tsx
@@ -1,6 +1,6 @@
 import { CheckIcon, CopyIcon } from "@chakra-ui/icons";
+import { CodeProps } from "react-markdown/lib/ast-to-react";
 import {
-  CodeProps,
   useClipboard,
   Stack,
   Code,
@@ -24,8 +24,11 @@ export const CodeInstruction: React.FC<CodeProps> = (props) => {
   }
 
   const { hasCopied, onCopy } = useClipboard(value);
-  return (
-    <Stack>
+
+  // if the code is inline should show in same line.
+  if(props?.inline){
+    return (
+      <div style={{display: "inline"}}>
       <Code
         padding={0}
         bg="white"
@@ -33,31 +36,61 @@ export const CodeInstruction: React.FC<CodeProps> = (props) => {
         borderColor="neutrals.300"
         borderWidth="1px"
       >
-        <Flex
-          borderColor="neutrals.300"
-          borderBottomWidth="1px"
-          py="8px"
-          px="16px"
-          minH="36px"
-        >
-          <Spacer />
+        <Text
+          color="neutrals.700"
+          paddingLeft={3}
+          whiteSpace="pre-wrap"
+        > 
+          {children}
+
           <IconButton
             variant="ghost"
-            h="20px"
+            h="10px"
+            style={{backgroundColor: "transparent"}}
             icon={hasCopied ? <CheckIcon /> : <CopyIcon />}
             onClick={onCopy}
             aria-label={"Copy"}
           />
-        </Flex>
-        <Text
-          overflowX="auto"
-          color="neutrals.700"
-          padding={4}
-          whiteSpace="pre-wrap"
-        >
-          {children}
-        </Text>
+         </Text>
       </Code>
-    </Stack>
+      </div>
+    )
+  }
+
+  return (
+    <Stack>
+    <Code
+      padding={0}
+      bg="white"
+      borderRadius="8px"
+      borderColor="neutrals.300"
+      borderWidth="1px"
+    >
+      <Flex
+        borderColor="neutrals.300"
+        borderBottomWidth="1px"
+        py="8px"
+        px="16px"
+        minH="36px"
+      >
+        <Spacer />
+        <IconButton
+          variant="ghost"
+          h="20px"
+          icon={hasCopied ? <CheckIcon /> : <CopyIcon />}
+          onClick={onCopy}
+          aria-label={"Copy"}
+        />
+      </Flex>
+      <Text
+        overflowX="auto"
+        color="neutrals.700"
+        padding={4}
+        whiteSpace="pre-wrap"
+      >
+        {children}
+      </Text>
+    </Code>
+  </Stack>
   );
 };

--- a/web/src/pages/admin/providers/setup/[id]/index.tsx
+++ b/web/src/pages/admin/providers/setup/[id]/index.tsx
@@ -512,7 +512,7 @@ const StepDisplay: React.FC<StepDisplayProps> = ({
                       {props.children}
                     </Text>
                   ),
-                  code: CodeInstruction as any,
+                  code: CodeInstruction,
                 }}
               >
                 {step.instructions}


### PR DESCRIPTION
### Fixes https://github.com/common-fate/granted-approvals/issues/219

### Summary of Change
1. Check whether `inline` prop  is set to true. If true then change the styling of the text. 

### Screenshot 
<img width="1441" alt="Screen Shot 2022-09-02 at 3 45 52 PM" src="https://user-images.githubusercontent.com/12543236/188068295-dfc6c5d3-02d8-4c57-a0a9-27ea704ac908.png">


