### PR TITLE
Fix nil pointer error in aws sso v2 provider

### DIFF
--- a/accesshandler/pkg/providers/aws/sso-v2/access.go
+++ b/accesshandler/pkg/providers/aws/sso-v2/access.go
@@ -79,7 +79,7 @@ func (p *Provider) Grant(ctx context.Context, subject string, args []byte, grant
 	}
 	// if the assignment was not successful, return the error and reason
 	if statusRes.AccountAssignmentCreationStatus.FailureReason != nil {
-		return fmt.Errorf("failed creating account assignment: %s", *res.AccountAssignmentCreationStatus.FailureReason)
+		return fmt.Errorf("failed creating account assignment: %s", *statusRes.AccountAssignmentCreationStatus.FailureReason)
 	}
 
 	return nil

--- a/accesshandler/pkg/runtime/lambda/granter/granter.go
+++ b/accesshandler/pkg/runtime/lambda/granter/granter.go
@@ -107,7 +107,7 @@ func (g *Granter) HandleRequest(ctx context.Context, in InputEvent) (Output, err
 
 	// emit an event and return early if we failed (de)provisioning the grant
 	if err != nil {
-		log.Error("granting error: %s", err.Error())
+		log.Errorf("error while handling granter event", "error", err.Error(), "event", in)
 
 		eventErr := eventsBus.Put(ctx, gevent.GrantFailed{Grant: grant, Reason: err.Error()})
 		if eventErr != nil {

--- a/cmd/gdeploy/commands/logs/get.go
+++ b/cmd/gdeploy/commands/logs/get.go
@@ -25,6 +25,7 @@ var getCommand = cli.Command{
 		&cli.StringSliceFlag{Name: "service", Aliases: []string{"sr"}, Usage: "The service to watch logs for. Services: " + strings.Join(ServiceNames, ", "), Required: false},
 		&cli.StringFlag{Name: "start", Usage: "Start time", Value: "-5m", Required: false},
 		&cli.StringFlag{Name: "end", Usage: "End time", Value: "now", Required: false},
+		&cli.StringFlag{Name: "filter", Usage: "Filter logs using a keyword, see the AWS documentation for details and syntax https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html"},
 	},
 	Description: "Get logs from CloudWatch",
 	Action: func(c *cli.Context) error {
@@ -96,7 +97,7 @@ var getCommand = cli.Command{
 					}
 				}
 				if hasLogs {
-					getEvents(GetEventsOpts{Group: logGroup, Start: start, End: end}, cfg.Region)
+					getEvents(GetEventsOpts{Group: logGroup, Start: start, End: end}, cfg.Region, c.String("filter"))
 				} else {
 					clio.Warn("No logs found for %s, the service may not have run yet. Log group id: %s", s, lg)
 				}
@@ -133,11 +134,12 @@ type GetEventsOpts struct {
 	End   string
 }
 
-func getEvents(opts GetEventsOpts, region string) {
+func getEvents(opts GetEventsOpts, region string, filter string) {
 	sawcfg := sawconfig.Configuration{
-		Group: opts.Group,
-		Start: opts.Start,
-		End:   opts.End,
+		Group:  opts.Group,
+		Start:  opts.Start,
+		End:    opts.End,
+		Filter: filter,
 	}
 
 	outputcfg := sawconfig.OutputConfiguration{

--- a/cmd/gdeploy/commands/logs/watch.go
+++ b/cmd/gdeploy/commands/logs/watch.go
@@ -20,6 +20,7 @@ var watchCommand = cli.Command{
 	Flags: []cli.Flag{
 		&cli.StringFlag{Name: "stack", Aliases: []string{"s"}, Usage: "The deployment stack to get logs for", DefaultText: "Your active stage in deployment.toml", Required: false},
 		&cli.StringSliceFlag{Name: "service", Aliases: []string{"sr"}, Usage: "The service to watch logs for. Services: " + strings.Join(ServiceNames, ", "), Required: false},
+		&cli.StringFlag{Name: "filter", Usage: "Filter logs using a keyword, see the AWS documentation for details and syntax https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html"},
 	},
 	Description: "Stream logs from CloudWatch",
 	Action: func(c *cli.Context) error {
@@ -67,7 +68,7 @@ var watchCommand = cli.Command{
 			wg.Add(1)
 			go func(lg, s string) {
 				clio.Info("Starting to watch logs for %s, log group id: %s", s, lg)
-				watchEvents(lg, cfg.Region)
+				watchEvents(lg, cfg.Region, c.String("filter"))
 				wg.Done()
 			}(logGroup, service)
 		}
@@ -78,9 +79,10 @@ var watchCommand = cli.Command{
 	},
 }
 
-func watchEvents(group string, region string) {
+func watchEvents(group string, region string, filter string) {
 	sawcfg := sawconfig.Configuration{
-		Group: group,
+		Group:  group,
+		Filter: filter,
 	}
 
 	outputcfg := sawconfig.OutputConfiguration{


### PR DESCRIPTION
This PR fixes a nil pointer error when handling errors in the AWS SSO V2 provider.

It also improves error handling for the granter by recovering panics safely and correctly reporting the status of the grant as Failed.
This will then propagate to the frontend audit log so the user knows that the grant has failed and they can reach out to us.
<img width="1332" alt="image" src="https://user-images.githubusercontent.com/14214200/188763452-fdba76e0-4778-4cca-b5c9-3e9a0be29c79.png">
