### PR TITLE
okta: handle cases where usernames don't match email

### DIFF
--- a/accesshandler/pkg/providers/okta/access.go
+++ b/accesshandler/pkg/providers/okta/access.go
@@ -69,7 +69,7 @@ func (p *Provider) IsActive(ctx context.Context, subject string, args []byte, gr
 
 func (p *Provider) getUserByEmail(ctx context.Context, email string) (*okta.User, error) {
 	users, _, err := p.client.User.ListUsers(ctx, &query.Params{
-		Search: fmt.Sprintf("profile.email = \"%s\"", email),
+		Search: fmt.Sprintf("profile.email eq \"%s\"", email),
 	})
 	if err != nil {
 		return nil, err

--- a/accesshandler/pkg/providers/okta/access.go
+++ b/accesshandler/pkg/providers/okta/access.go
@@ -69,7 +69,7 @@ func (p *Provider) IsActive(ctx context.Context, subject string, args []byte, gr
 
 func (p *Provider) getUserByEmail(ctx context.Context, email string) (*okta.User, error) {
 	users, _, err := p.client.User.ListUsers(ctx, &query.Params{
-		Search: fmt.Sprintf("profile.email = %s", email),
+		Search: fmt.Sprintf("profile.email = \"%s\"", email),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In some Okta tenancies, users have a username in the format `firstname.lastname` which doesn't match their email address. Granted Approvals uses email address to lookup users. This PR uses the Okta [List Users With Search](https://developer.okta.com/docs/reference/api/users/#known-limitation) API to match users by their email address.