### PR TITLE
Add Remove & Update subcommand for providers 

### DIFF
--- a/accesshandler/pkg/providerregistry/registry.go
+++ b/accesshandler/pkg/providerregistry/registry.go
@@ -89,7 +89,7 @@ func Registry() ProviderRegistry {
 
 // Lookup a provider by the 'uses' string.
 func (r ProviderRegistry) LookupByUses(uses string) (*RegisteredProvider, error) {
-	ptype, version, err := parseUses(uses)
+	ptype, version, err := ParseUses(uses)
 	if err != nil {
 		return nil, err
 	}

--- a/accesshandler/pkg/providerregistry/registry.go
+++ b/accesshandler/pkg/providerregistry/registry.go
@@ -133,7 +133,7 @@ func (r ProviderRegistry) GetLatestByType(providerType string) (latestVersion st
 	return latestVersion, &pv, nil
 }
 
-func parseUses(uses string) (providerType string, version string, err error) {
+func ParseUses(uses string) (providerType string, version string, err error) {
 	// 'uses' is a field like "commonfate/testvault@v1".
 	// we need to split it into a type ("commonfate/testvault")
 	// and a version ("v1")

--- a/cmd/gdeploy/commands/provider/add.go
+++ b/cmd/gdeploy/commands/provider/add.go
@@ -116,11 +116,11 @@ var addCommand = cli.Command{
 			// parse the key=value pairs in the 'with' argument.
 			for _, kv := range withArgs {
 				segments := strings.Split(kv, "=")
-				key, val := segments[0], segments[1]
 				if len(segments) != 2 {
 					return fmt.Errorf("could not parse 'with' argument %s: must be in key=value format", kv)
 				}
 
+				key, val := segments[0], segments[1]
 				with[key] = val
 			}
 		}

--- a/cmd/gdeploy/commands/provider/provider.go
+++ b/cmd/gdeploy/commands/provider/provider.go
@@ -8,7 +8,7 @@ var Command = cli.Command{
 	Description: "Manage your Access Providers",
 	Usage:       "Manage your Access Providers",
 	Subcommands: []*cli.Command{
-		&addCommand, &removeCommand,
+		&addCommand, &removeCommand, &updateCommand,
 	},
 	Action: cli.ShowSubcommandHelp,
 }

--- a/cmd/gdeploy/commands/provider/provider.go
+++ b/cmd/gdeploy/commands/provider/provider.go
@@ -8,7 +8,7 @@ var Command = cli.Command{
 	Description: "Manage your Access Providers",
 	Usage:       "Manage your Access Providers",
 	Subcommands: []*cli.Command{
-		&addCommand,
+		&addCommand, &removeCommand,
 	},
 	Action: cli.ShowSubcommandHelp,
 }

--- a/cmd/gdeploy/commands/provider/remove.go
+++ b/cmd/gdeploy/commands/provider/remove.go
@@ -1,0 +1,84 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/common-fate/granted-approvals/pkg/clio"
+	"github.com/common-fate/granted-approvals/pkg/deploy"
+	"github.com/urfave/cli/v2"
+)
+
+var removeCommand = cli.Command{
+	Name:        "remove",
+	Description: "Remove an existing access provider",
+	Flags: []cli.Flag{
+		&cli.StringFlag{Name: "id", Usage: "An identifier of the provider to be removed."},
+	},
+	Action: func(c *cli.Context) error {
+		ctx := c.Context
+		dc, err := deploy.ConfigFromContext(ctx)
+		if err != nil {
+			return err
+		}
+
+		var chosen string
+		id := c.String("id")
+
+		// if no '-id' flag provided then stdout current providers as options to choose from.
+		if id == "" {
+			userProvidersMap := dc.Deployment.Parameters.ProviderConfiguration
+
+			var CLIOptions []string
+
+			for k := range userProvidersMap {
+				CLIOptions = append(CLIOptions, k)
+			}
+
+			p := survey.Select{
+				Message: "Select the id of the Provider that you want to remove",
+				Options: CLIOptions,
+			}
+
+			err = survey.AskOne(&p, &chosen)
+			if err != nil {
+				return err
+			}
+
+		} else {
+			chosen = id
+		}
+
+		if _, ok := dc.Deployment.Parameters.ProviderConfiguration[chosen]; !ok {
+			clio.Error("Provider configuration doesn't exist. Unable to remove provider '%s'", chosen)
+			return nil
+		}
+
+		var confirm bool
+		prompt := &survey.Confirm{
+			Message: fmt.Sprintf("Are you sure you want to remove '%s'", chosen),
+		}
+
+		err = survey.AskOne(prompt, &confirm)
+		if err != nil {
+			return err
+		}
+
+		if !confirm {
+			clio.Info("Removing provider aborted.")
+			return nil
+		}
+
+		delete(dc.Deployment.Parameters.ProviderConfiguration, chosen)
+
+		f := c.Path("file")
+		err = dc.Save(f)
+		if err != nil {
+			return err
+		}
+
+		clio.Success("Successfully removed provider %s", chosen)
+		clio.Warn("Your changes won't be applied until you redeploy. Run 'gdeploy update' to apply the changes to your CloudFormation deployment.")
+		return nil
+	},
+}

--- a/cmd/gdeploy/commands/provider/update.go
+++ b/cmd/gdeploy/commands/provider/update.go
@@ -1,0 +1,150 @@
+package provider
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/common-fate/granted-approvals/accesshandler/pkg/providerregistry"
+	"github.com/common-fate/granted-approvals/pkg/clio"
+	"github.com/common-fate/granted-approvals/pkg/deploy"
+	"github.com/common-fate/granted-approvals/pkg/gconfig"
+	"github.com/urfave/cli/v2"
+)
+
+var updateCommand = cli.Command{
+	Name:        "update",
+	Description: "Update configuration for existing provider",
+	Flags: []cli.Flag{
+		&cli.StringFlag{Name: "id", Usage: "An identifier for the provider"},
+		&cli.StringSliceFlag{Name: "with", Usage: "Configuration settings for the provider, in key=value pairs"},
+	},
+	Action: func(c *cli.Context) error {
+		ctx := c.Context
+		dc, err := deploy.ConfigFromContext(ctx)
+		if err != nil {
+			return err
+		}
+
+		var chosen string
+		id := c.String("id")
+
+		// if no '-id' flag provided then stdout current providers as options to choose from.
+		if id == "" {
+			userProvidersMap := dc.Deployment.Parameters.ProviderConfiguration
+
+			var CLIOptions []string
+			for k := range userProvidersMap {
+				CLIOptions = append(CLIOptions, k)
+			}
+
+			p := survey.Select{
+				Message: "Select the id of the Provider that you want to update",
+				Options: CLIOptions,
+			}
+
+			err = survey.AskOne(&p, &chosen)
+			if err != nil {
+				return err
+			}
+
+		} else {
+			chosen = id
+		}
+
+		if _, ok := dc.Deployment.Parameters.ProviderConfiguration[chosen]; !ok {
+			clio.Error("Provider configuration doesn't exist. Unable to remove provider '%s'", chosen)
+			clio.Log("Try using 'gdeploy providers add' to add a new provider.")
+			return nil
+		}
+
+		with := map[string]string{}
+		withArgs := c.StringSlice("with")
+		uses := ""
+
+		r := providerregistry.Registry()
+
+		// Need to figure out the registeredProvider from chosen option.
+		// Parse uses to see provider type and use lookup func to get the actual registered provider.
+		currentConfig := dc.Deployment.Parameters.ProviderConfiguration[chosen]
+		uses = currentConfig.Uses
+		providerType, version, err := providerregistry.ParseUses(uses)
+		if err != nil {
+			fmt.Println(err)
+			return err
+		}
+
+		registeredProvider, err := r.Lookup(providerType, version)
+		if err != nil {
+			return err
+		}
+
+		if len(withArgs) == 0 {
+			var pcfg gconfig.Config
+			if configer, ok := registeredProvider.Provider.(gconfig.Configer); ok {
+				pcfg = configer.Config()
+
+				// load the current values into this config
+				err = pcfg.Load(ctx, &gconfig.MapLoader{Values: currentConfig.With})
+				if err != nil {
+					return err
+				}
+
+				// CLI prompt will have defaults values loaded.
+				for _, v := range pcfg {
+					err := deploy.CLIPrompt(v)
+					if err != nil {
+						return err
+					}
+				}
+			}
+
+			err = deploy.RunConfigTest(ctx, registeredProvider.Provider)
+			if err != nil {
+				return err
+			}
+
+			// if tests pass, dump the config and update in the deployment config
+			// secret path args requires the id, all provider config includes the provider ID in the path
+			with, err = pcfg.Dump(ctx, gconfig.SSMDumper{Suffix: dc.Deployment.Parameters.DeploymentSuffix, SecretPathArgs: []interface{}{id}})
+			if err != nil {
+				return err
+			}
+
+		} else {
+			// The user has provided some config via the --with arguments, so skip the interactive flow. The user has likely used the
+			// guided setup UI, or they know what they're doing.
+			//
+			// We also skip writing secrets to SSM, as we assume they have already been written. We don't support passing secrets via '--with'
+			// as it pollutes the user's shell history with their credentials.
+			//
+			// We could perform a configuration test here in future to provide some extra assurance to the user that their values are correct.
+
+			// parse the key=value pairs in the 'with' argument.
+			for _, kv := range withArgs {
+				segments := strings.Split(kv, "=")
+				if len(segments) != 2 {
+					return fmt.Errorf("could not parse 'with' argument %s: must be in key=value format", kv)
+				}
+				key, val := segments[0], segments[1]
+
+				with[key] = val
+			}
+		}
+
+		err = dc.Deployment.Parameters.ProviderConfiguration.Update(chosen, deploy.Provider{Uses: uses, With: with})
+		if err != nil {
+			return err
+		}
+
+		f := c.Path("file")
+		err = dc.Save(f)
+		if err != nil {
+			return err
+		}
+
+		clio.Success("wrote config to %s", f)
+		clio.Warn("Your changes won't be applied until you redeploy. Run 'gdeploy update' to apply the changes to your CloudFormation deployment.")
+		return nil
+	},
+}

--- a/pkg/deploy/config.go
+++ b/pkg/deploy/config.go
@@ -93,7 +93,7 @@ func (f *ProviderMap) Add(id string, p Provider) error {
 // Update the Provider if it exist
 func (f *ProviderMap) Update(id string, p Provider) error {
 	if _, ok := (*f)[id]; !ok {
-		return fmt.Errorf("provider %s doesnot exists in the config", id)
+		return fmt.Errorf("provider %s not found in config", id)
 	}
 
 	(*f)[id] = p

--- a/pkg/deploy/config.go
+++ b/pkg/deploy/config.go
@@ -90,6 +90,16 @@ func (f *ProviderMap) Add(id string, p Provider) error {
 	return nil
 }
 
+// Update the Provider if it exist
+func (f *ProviderMap) Update(id string, p Provider) error {
+	if _, ok := (*f)[id]; !ok {
+		return fmt.Errorf("provider %s doesnot exists in the config", id)
+	}
+
+	(*f)[id] = p
+	return nil
+}
+
 // GetIDForNewProvider returns an ID for a provider based on the following rules:
 //
 // 1. If the provider isn't used in the config, the default ID is returned (e.g. `aws-sso`).


### PR DESCRIPTION
### Description
1. Add `gdeploy update providers` & `gdeploy remove providers` subcmds. 
2. Fix issue when invalid `with=` arg is provided in `add` cmd. 

### Note
1. When providing `--with apple=orange` no check is done. So, essentially if users want to add dumb key=value, it will override the previous values for that provider. 
