### PR TITLE
Azure AD IDP: support custom email identifier field

### DIFF
--- a/cmd/lambda/syncer/handler.go
+++ b/cmd/lambda/syncer/handler.go
@@ -43,6 +43,6 @@ func main() {
 		panic(err)
 	}
 	zap.ReplaceGlobals(log.Desugar())
-	zap.S().Infow("starting sync with configuration")
+	zap.S().Infow("starting sync", "config", ic, "idp.type", cfg.IdpProvider)
 	lambda.Start(syncer.Sync)
 }

--- a/pkg/identity/identitysync/azure_test.go
+++ b/pkg/identity/identitysync/azure_test.go
@@ -1,0 +1,144 @@
+package identitysync
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/common-fate/granted-approvals/pkg/gconfig"
+	"github.com/common-fate/granted-approvals/pkg/identity"
+)
+
+func TestAzureSync_idpUserFromAzureUser(t *testing.T) {
+	mail := "mail"
+	invalidIdentifer := "invalid"
+
+	type fields struct {
+		token           gconfig.SecretStringValue
+		tenantID        gconfig.StringValue
+		clientID        gconfig.StringValue
+		clientSecret    gconfig.SecretStringValue
+		emailIdentifier gconfig.OptionalStringValue
+	}
+	type args struct {
+		ctx       context.Context
+		azureUser map[string]interface{}
+		groups    []string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    identity.IDPUser
+		wantErr bool
+	}{
+		{
+			name: "ok",
+			args: args{
+				ctx: context.Background(),
+				azureUser: map[string]interface{}{
+					"businessPhones":    []string{"425-555-0100"},
+					"displayName":       "MOD Administrator",
+					"givenName":         "MOD",
+					"jobTitle":          nil,
+					"mail":              nil,
+					"mobilePhone":       "425-555-0101",
+					"officeLocation":    nil,
+					"preferredLanguage": "en-US",
+					"surname":           "Administrator",
+					"userPrincipalName": "admin@contoso.com",
+					"id":                "4562bcc8-c436-4f95-b7c0-4f8ce89dca5e",
+				},
+			},
+			want: identity.IDPUser{
+				ID:        "4562bcc8-c436-4f95-b7c0-4f8ce89dca5e",
+				FirstName: "MOD",
+				LastName:  "Administrator",
+				Email:     "admin@contoso.com",
+			},
+		},
+		{
+			name: "assign groups",
+			args: args{
+				ctx: context.Background(),
+				azureUser: map[string]interface{}{
+					"givenName":         "MOD",
+					"surname":           "Administrator",
+					"userPrincipalName": "admin@contoso.com",
+					"id":                "4562bcc8-c436-4f95-b7c0-4f8ce89dca5e",
+				},
+				groups: []string{"a", "b"},
+			},
+			want: identity.IDPUser{
+				ID:        "4562bcc8-c436-4f95-b7c0-4f8ce89dca5e",
+				FirstName: "MOD",
+				LastName:  "Administrator",
+				Email:     "admin@contoso.com",
+				Groups:    []string{"a", "b"},
+			},
+		},
+		{
+			name: "handle custom email identifier",
+			fields: fields{
+				// use the 'mail' attribute from the Azure AD API response.
+				emailIdentifier: gconfig.OptionalStringValue{Value: &mail},
+			},
+			args: args{
+				ctx: context.Background(),
+				azureUser: map[string]interface{}{
+					"givenName": "MOD",
+					"surname":   "Administrator",
+					// in this case, the UPN is an external user.
+					"userPrincipalName": "admin#EXT@contoso.com",
+					"mail":              "admin@contoso.com",
+					"id":                "4562bcc8-c436-4f95-b7c0-4f8ce89dca5e",
+				},
+				groups: []string{"a", "b"},
+			},
+			want: identity.IDPUser{
+				ID:        "4562bcc8-c436-4f95-b7c0-4f8ce89dca5e",
+				FirstName: "MOD",
+				LastName:  "Administrator",
+				Email:     "admin@contoso.com",
+				Groups:    []string{"a", "b"},
+			},
+		},
+		{
+			name: "invalid email identifier",
+			fields: fields{
+				emailIdentifier: gconfig.OptionalStringValue{Value: &invalidIdentifer},
+			},
+			args: args{
+				ctx: context.Background(),
+				azureUser: map[string]interface{}{
+					"givenName":         "MOD",
+					"surname":           "Administrator",
+					"userPrincipalName": "admin#EXT@contoso.com",
+					"mail":              "admin@contoso.com",
+					"id":                "4562bcc8-c436-4f95-b7c0-4f8ce89dca5e",
+				},
+				groups: []string{"a", "b"},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &AzureSync{
+				token:           tt.fields.token,
+				tenantID:        tt.fields.tenantID,
+				clientID:        tt.fields.clientID,
+				clientSecret:    tt.fields.clientSecret,
+				emailIdentifier: tt.fields.emailIdentifier,
+			}
+			got, err := a.idpUserFromAzureUser(tt.args.ctx, tt.args.azureUser, tt.args.groups)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AzureSync.idpUserFromAzureUser() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AzureSync.idpUserFromAzureUser() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/identity/identitysync/sync.go
+++ b/pkg/identity/identitysync/sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/common-fate/apikit/logger"
 	"github.com/common-fate/ddb"
 	"github.com/common-fate/granted-approvals/pkg/deploy"
 	"github.com/common-fate/granted-approvals/pkg/gconfig"
@@ -77,6 +78,8 @@ func NewIdentitySyncer(ctx context.Context, opts SyncOpts) (*IdentitySyncer, err
 }
 
 func (s *IdentitySyncer) Sync(ctx context.Context) error {
+	log := logger.Get(ctx)
+
 	//Fetch all users from IDP
 	// The IDP should return the group mappings for users, these group IDs will be internal to the IDP
 	idpUsers, err := s.idp.ListUsers(ctx)
@@ -88,6 +91,8 @@ func (s *IdentitySyncer) Sync(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	log.Infow("fetched users and groups from IDP", "users.count", len(idpUsers), "groups.count", len(idpGroups))
 
 	uq := &storage.ListUsers{}
 	_, err = s.db.Query(ctx, uq)


### PR DESCRIPTION
Adds an optional 'emailIdentifier' parameter to the Azure IDP sync which allows users to specify a custom field to be used as the email address of the user. The field must match the [Azure AD user properties](https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties).