### PR TITLE
fix: Disable "Approve" button when self-reviewing

### DIFF
--- a/web/src/components/Request.tsx
+++ b/web/src/components/Request.tsx
@@ -651,7 +651,7 @@ export const RequestReview: React.FC<ReviewButtonsProps> = ({
                   <Button
                     data-testid="approve"
                     isLoading={isSubmitting === "APPROVED"}
-                    isDisabled={isSubmitting === "DECLINED"}
+                    isDisabled={isSubmitting === "DECLINED" || !canReview}
                     autoFocus={focus === "approve"}
                     variant={"brandPrimary"}
                     key={1}


### PR DESCRIPTION
The button already does nothing and has a tooltip explaining why, but
it's still enabled.