### PR TITLE
fix 128 character limitation on description length

### DIFF
--- a/web/src/components/forms/access-rule/steps/General.tsx
+++ b/web/src/components/forms/access-rule/steps/General.tsx
@@ -52,12 +52,10 @@ export const GeneralStep: React.FC = () => {
           <FormLabel htmlFor="Description">
             <Text textStyle={"Body/Medium"}>Description</Text>
           </FormLabel>
-          {/* arbitrary max length - not yet enforced at the API level */}
           <Textarea
             bg="neutrals.0"
             {...methods.register("description", {
               required: true,
-              maxLength: 128,
             })}
             onBlur={() => void methods.trigger("description")}
           />


### PR DESCRIPTION
Users receive a poor UX error message on longer descriptions. Just send it as-is to the API, if the request size ends up being too large it will be rejected.
<img width="766" alt="image" src="https://user-images.githubusercontent.com/17420369/191796537-5d97f4a3-8dd9-47e6-9ab7-6333bcfbfbee.png">
