### PR TITLE
feat(aws-sso-v2): show more browser setup details

### DIFF
--- a/accesshandler/pkg/providers/aws/sso-v2/access.go
+++ b/accesshandler/pkg/providers/aws/sso-v2/access.go
@@ -253,7 +253,9 @@ func (p *Provider) Instructions(ctx context.Context, subject string, args []byte
 	url := fmt.Sprintf("https://%s.awsapps.com/start", p.identityStoreID.Get())
 
 	i := "# Browser\n"
-	i += fmt.Sprintf("You can access this role at your [AWS SSO URL](%s)\n\n", url)
+	i += fmt.Sprintf("You can access this role at your [AWS SSO URL](%s).\n\n", url)
+	i += fmt.Sprintf("* Account ID: _%s_\n", a.AccountID)
+	i += fmt.Sprintf("* Role: _%s_\n\n", *po.PermissionSet.Name)
 	i += "# CLI\n"
 	i += "Ensure that you've [installed](https://docs.commonfate.io/granted/getting-started#installing-the-cli) the Granted CLI, then run:\n\n"
 	i += "```\n"


### PR DESCRIPTION
Specify the role name and account ID.

Ideally we could show the account name rather than ID, but this requires a call to the AWS Org client, so we'd need some way to cache the data. And I don't know how to do that... :thinking: