### PR TITLE
feat(web): Use relative timestamps in audit log

### DIFF
--- a/web/src/components/AuditLog.tsx
+++ b/web/src/components/AuditLog.tsx
@@ -47,7 +47,7 @@ export const AuditLog: React.FC<{ request?: RequestDetail }> = ({
             header={<Text>Grant created</Text>}
             index={i}
             key={i}
-            body={new Date(e.createdAt).toString()}
+            timestamp={new Date(e.createdAt)}
           />
         );
       } else if (e.fromGrantStatus && e.actor) {
@@ -63,7 +63,7 @@ export const AuditLog: React.FC<{ request?: RequestDetail }> = ({
             }
             index={i}
             key={i}
-            body={new Date(e.createdAt).toString()}
+            timestamp={new Date(e.createdAt)}
           />
         );
       } else if (e.fromGrantStatus && e.grantFailureReason) {
@@ -105,7 +105,7 @@ export const AuditLog: React.FC<{ request?: RequestDetail }> = ({
             }
             index={i}
             key={i}
-            body={new Date(e.createdAt).toString()}
+            timestamp={new Date(e.createdAt)}
           />
         );
       } else if (e.fromGrantStatus) {
@@ -120,7 +120,7 @@ export const AuditLog: React.FC<{ request?: RequestDetail }> = ({
             }
             index={i}
             key={i}
-            body={new Date(e.createdAt).toString()}
+            timestamp={new Date(e.createdAt)}
           />
         );
       } else if (e.fromTiming && e.actor) {
@@ -136,7 +136,7 @@ export const AuditLog: React.FC<{ request?: RequestDetail }> = ({
             }
             index={i}
             key={i}
-            body={new Date(e.createdAt).toString()}
+            timestamp={new Date(e.createdAt)}
           />
         );
       } else if (e.fromStatus && e.actor) {
@@ -152,7 +152,7 @@ export const AuditLog: React.FC<{ request?: RequestDetail }> = ({
             }
             index={i}
             key={i}
-            body={new Date(e.createdAt).toString()}
+            timestamp={new Date(e.createdAt)}
           />
         );
       } else if (e.fromStatus?.toLowerCase()) {
@@ -167,7 +167,7 @@ export const AuditLog: React.FC<{ request?: RequestDetail }> = ({
             }
             index={i}
             key={i}
-            body={new Date(e.createdAt).toString()}
+            timestamp={new Date(e.createdAt)}
           />
         );
       } else if (e.requestCreated) {
@@ -182,7 +182,7 @@ export const AuditLog: React.FC<{ request?: RequestDetail }> = ({
             }
             index={i}
             key={i}
-            body={new Date(e.createdAt).toString()}
+            timestamp={new Date(e.createdAt)}
           />
         );
       } else if (e.recordedEvent) {
@@ -219,7 +219,7 @@ export const AuditLog: React.FC<{ request?: RequestDetail }> = ({
               </Stack>
             }
             index={i}
-            body={new Date(e.createdAt).toString()}
+            timestamp={new Date(e.createdAt)}
           />
         );
       }

--- a/web/src/components/CFTimelineRow.tsx
+++ b/web/src/components/CFTimelineRow.tsx
@@ -1,18 +1,25 @@
-import { Box, Flex, Text, useColorModeValue } from "@chakra-ui/react";
+import { Box, Flex, Text, Tooltip, useColorModeValue } from "@chakra-ui/react";
+import { formatDistanceToNowStrict } from "date-fns";
 import React from "react";
 
 interface Props {
   header: React.ReactNode;
-  body?: React.ReactNode;
+  timestamp: Date;
   /** this should be a 20px react node (use boxSize with chakra elements) */
   marker?: React.ReactNode;
   index: number;
   arrLength: number;
 }
 
+const TimestampLine = React.forwardRef<React.ReactNode, { timestamp: Date }>(({ timestamp }, ref) => (
+  <Text fontSize="sm" color="gray.400" fontWeight="normal">
+    {formatDistanceToNowStrict(timestamp, {addSuffix: true})}
+  </Text>
+))
+
 export const CFTimelineRow = ({
   header,
-  body,
+  timestamp,
   marker,
   index,
   arrLength,
@@ -55,9 +62,11 @@ export const CFTimelineRow = ({
         <Text fontSize="sm" color={textColor} fontWeight="bold">
           {header}
         </Text>
-        <Text fontSize="sm" color="gray.400" fontWeight="normal">
-          {body}
-        </Text>
+        <Tooltip label={timestamp.toString()}>
+          <Text fontSize="sm" color="gray.400" fontWeight="normal">
+            {formatDistanceToNowStrict(timestamp, {addSuffix: true})}
+          </Text>
+        </Tooltip>
       </Flex>
     </Flex>
   );


### PR DESCRIPTION
But preserve the full timestamp as a tooltip.