### PR TITLE
update formatting on access instructions for AWS SSO

### DIFF
--- a/accesshandler/pkg/providers/aws/sso-v2/access.go
+++ b/accesshandler/pkg/providers/aws/sso-v2/access.go
@@ -254,8 +254,8 @@ func (p *Provider) Instructions(ctx context.Context, subject string, args []byte
 
 	i := "# Browser\n"
 	i += fmt.Sprintf("You can access this role at your [AWS SSO URL](%s).\n\n", url)
-	i += fmt.Sprintf("* Account ID: _%s_\n", a.AccountID)
-	i += fmt.Sprintf("* Role: _%s_\n\n", *po.PermissionSet.Name)
+	i += fmt.Sprintf("Account ID: %s\n", a.AccountID)
+	i += fmt.Sprintf("Role: %s\n\n", *po.PermissionSet.Name)
 	i += "# CLI\n"
 	i += "Ensure that you've [installed](https://docs.commonfate.io/granted/getting-started#installing-the-cli) the Granted CLI, then run:\n\n"
 	i += "```\n"

--- a/accesshandler/pkg/providers/aws/sso-v2/access.go
+++ b/accesshandler/pkg/providers/aws/sso-v2/access.go
@@ -254,7 +254,7 @@ func (p *Provider) Instructions(ctx context.Context, subject string, args []byte
 
 	i := "# Browser\n"
 	i += fmt.Sprintf("You can access this role at your [AWS SSO URL](%s).\n\n", url)
-	i += fmt.Sprintf("Account ID: %s\n", a.AccountID)
+	i += fmt.Sprintf("Account ID: %s\n\n", a.AccountID)
 	i += fmt.Sprintf("Role: %s\n\n", *po.PermissionSet.Name)
 	i += "# CLI\n"
 	i += "Ensure that you've [installed](https://docs.commonfate.io/granted/getting-started#installing-the-cli) the Granted CLI, then run:\n\n"

--- a/accesshandler/pkg/providers/aws/sso-v2/access.go
+++ b/accesshandler/pkg/providers/aws/sso-v2/access.go
@@ -254,8 +254,8 @@ func (p *Provider) Instructions(ctx context.Context, subject string, args []byte
 
 	i := "# Browser\n"
 	i += fmt.Sprintf("You can access this role at your [AWS SSO URL](%s).\n\n", url)
-	i += fmt.Sprintf("Account ID: %s\n\n", a.AccountID)
-	i += fmt.Sprintf("Role: %s\n\n", *po.PermissionSet.Name)
+	i += fmt.Sprintf("**Account ID**: %s\n\n", a.AccountID)
+	i += fmt.Sprintf("**Role**: %s\n\n", *po.PermissionSet.Name)
 	i += "# CLI\n"
 	i += "Ensure that you've [installed](https://docs.commonfate.io/granted/getting-started#installing-the-cli) the Granted CLI, then run:\n\n"
 	i += "```\n"


### PR DESCRIPTION
We don't have proper formatting in place for `<ul>` elements, so the text is a bit darker than the rest of the instructions:

<img width="666" alt="image" src="https://user-images.githubusercontent.com/17420369/192519615-d9ef40b8-88cc-4c38-9766-8e5d2497c1c4.png">


I've removed the `*` characters so that the text is more consistent.
