### PR TITLE
Fix Access Rule lookup for Permission Sets that have a description

### DIFF
--- a/pkg/api/accessrule.go
+++ b/pkg/api/accessrule.go
@@ -226,7 +226,7 @@ func (a *API) AccessRuleLookup(w http.ResponseWriter, r *http.Request, params ty
 		apio.Error(ctx, w, err)
 	}
 
-	logger.Get(ctx).Infow("found provider", "provider")
+	logger.Get(ctx).Infow("found provider", "provider", p)
 
 	//	filter by params.AccountId
 Filterloop:

--- a/pkg/api/accessrule.go
+++ b/pkg/api/accessrule.go
@@ -226,13 +226,11 @@ func (a *API) AccessRuleLookup(w http.ResponseWriter, r *http.Request, params ty
 		apio.Error(ctx, w, err)
 	}
 
-	logger.Get(ctx).Infow("found provider", "provider", p, "rules.query", q, "params", params)
+	logger.Get(ctx).Infow("found provider", "provider")
 
 	//	filter by params.AccountId
 Filterloop:
 	for _, r := range q.Result {
-		log := logger.Get(ctx).With("rule.id", r.ID)
-		log.Infow("evaluating rule", "rule", r)
 		switch p.DefaultID {
 		case "aws-sso-v2":
 			// we must support string and []string for With/WithSelectable
@@ -241,7 +239,6 @@ Filterloop:
 			if !found {
 				ruleAccIds, found = r.Target.ToAPI().WithSelectable.Get("accountId")
 				if !found {
-					log.Infow("skipped", "reason", "no accountId found")
 					continue Filterloop // if not found continue
 				}
 			} else {
@@ -251,7 +248,6 @@ Filterloop:
 			for _, ruleAccId := range ruleAccIds {
 				reqAccId := (*params.AccountId)
 				if reqAccId != ruleAccId {
-					log.Infow("skipped", "reason", "reqAccId != ruleAccId", "reqAccId", reqAccId, "ruleAccId", ruleAccId)
 					continue Filterloop // if not found continue
 				}
 
@@ -275,8 +271,6 @@ Filterloop:
 						done = true
 					}
 				}
-
-				log.Infow("evaluating permission set ARN label", "want", params.PermissionSetArnLabel, "have", q)
 
 				for _, po := range permissionSets {
 					// The label is not good to match on, but for our current data structures it's the best we've got.

--- a/pkg/api/accessrule.go
+++ b/pkg/api/accessrule.go
@@ -224,8 +224,8 @@ func (a *API) AccessRuleLookup(w http.ResponseWriter, r *http.Request, params ty
 
 	//	filter by params.AccountId
 	for _, r := range q.Result {
-		log := logger.Get(ctx).With("rule", r)
-		log.Info("evaluating rule")
+		log := logger.Get(ctx).With("rule.id", r.ID)
+		log.Infow("evaluating rule", "rule", r)
 		switch p.DefaultID {
 		case "aws-sso-v2":
 			// we must support string and []string for With/WithSelectable
@@ -234,7 +234,7 @@ func (a *API) AccessRuleLookup(w http.ResponseWriter, r *http.Request, params ty
 			if !found {
 				ruleAccIds, found = r.Target.ToAPI().WithSelectable.Get("accountId")
 				if !found {
-					log.Info("skipped", "reason", "no accountId found")
+					log.Infow("skipped", "reason", "no accountId found")
 					continue // if not found continue
 				}
 			} else {
@@ -244,7 +244,7 @@ func (a *API) AccessRuleLookup(w http.ResponseWriter, r *http.Request, params ty
 			for _, ruleAccId := range ruleAccIds {
 				reqAccId := (*params.AccountId)
 				if reqAccId != ruleAccId {
-					log.Info("skipped", "reason", "reqAccId != ruleAccId", "reqAccId", reqAccId, "ruleAccId", ruleAccId)
+					log.Infow("skipped", "reason", "reqAccId != ruleAccId", "reqAccId", reqAccId, "ruleAccId", ruleAccId)
 					continue // if not found continue
 				}
 				// lookup ProviderOptions for given rule and get the
@@ -255,7 +255,7 @@ func (a *API) AccessRuleLookup(w http.ResponseWriter, r *http.Request, params ty
 					continue
 				}
 
-				log.Info("evaluating permission set ARN label", "want", params.PermissionSetArnLabel, "have", q)
+				log.Infow("evaluating permission set ARN label", "want", params.PermissionSetArnLabel, "have", q)
 
 				for _, po := range q.Result {
 					if po.Label == (*params.PermissionSetArnLabel) {

--- a/pkg/api/accessrule.go
+++ b/pkg/api/accessrule.go
@@ -196,6 +196,9 @@ func (a *API) AdminGetAccessRuleVersion(w http.ResponseWriter, r *http.Request, 
 // (GET /api/v1/access-rules/lookup)
 func (a *API) AccessRuleLookup(w http.ResponseWriter, r *http.Request, params types.AccessRuleLookupParams) {
 	ctx := r.Context()
+
+	logger.Get(ctx).Infow("looking up access rule", "params", params)
+
 	// fetch all active access rules
 	u := auth.UserFromContext(ctx)
 	q := storage.ListAccessRulesForGroupsAndStatus{Groups: u.Groups, Status: rule.ACTIVE}


### PR DESCRIPTION
Fixes a bug where Access Rules wouldn't be found if the AWS SSO Permission Set had a description.