### PR TITLE
Bugfix: failed grant requests can be cancelled 

### DIFF
--- a/accesshandler/pkg/providers/aws/sso-v2/access.go
+++ b/accesshandler/pkg/providers/aws/sso-v2/access.go
@@ -22,67 +22,68 @@ type Args struct {
 
 // Grant the access by calling the AWS SSO API.
 func (p *Provider) Grant(ctx context.Context, subject string, args []byte, grantID string) error {
-	var a Args
-	err := json.Unmarshal(args, &a)
-	if err != nil {
-		return err
-	}
+	return fmt.Errorf("testing")
+	// var a Args
+	// err := json.Unmarshal(args, &a)
+	// if err != nil {
+	// 	return err
+	// }
 
-	// ensure that the account exists in the organization. If it doesn't, calling CreateAccountAssignment
-	// will silently fail without returning an error.
-	err = p.ensureAccountExists(ctx, a.AccountID)
-	if err != nil {
-		return err
-	}
+	// // ensure that the account exists in the organization. If it doesn't, calling CreateAccountAssignment
+	// // will silently fail without returning an error.
+	// err = p.ensureAccountExists(ctx, a.AccountID)
+	// if err != nil {
+	// 	return err
+	// }
 
-	// find the user ID from the provided email address.
-	user, err := p.getUser(ctx, subject)
-	if err != nil {
-		return err
-	}
+	// // find the user ID from the provided email address.
+	// user, err := p.getUser(ctx, subject)
+	// if err != nil {
+	// 	return err
+	// }
 
-	res, err := p.client.CreateAccountAssignment(ctx, &ssoadmin.CreateAccountAssignmentInput{
-		InstanceArn:      aws.String(p.instanceARN.Get()),
-		PermissionSetArn: &a.PermissionSetARN,
-		PrincipalType:    types.PrincipalTypeUser,
-		PrincipalId:      user.UserId,
-		TargetId:         &a.AccountID,
-		TargetType:       types.TargetTypeAwsAccount,
-	})
-	if err != nil {
-		return err
-	}
+	// res, err := p.client.CreateAccountAssignment(ctx, &ssoadmin.CreateAccountAssignmentInput{
+	// 	InstanceArn:      aws.String(p.instanceARN.Get()),
+	// 	PermissionSetArn: &a.PermissionSetARN,
+	// 	PrincipalType:    types.PrincipalTypeUser,
+	// 	PrincipalId:      user.UserId,
+	// 	TargetId:         &a.AccountID,
+	// 	TargetType:       types.TargetTypeAwsAccount,
+	// })
+	// if err != nil {
+	// 	return err
+	// }
 
-	if res.AccountAssignmentCreationStatus.FailureReason != nil {
-		return fmt.Errorf("failed creating account assignment: %s", *res.AccountAssignmentCreationStatus.FailureReason)
-	}
+	// if res.AccountAssignmentCreationStatus.FailureReason != nil {
+	// 	return fmt.Errorf("failed creating account assignment: %s", *res.AccountAssignmentCreationStatus.FailureReason)
+	// }
 
-	// poll the assignment api to check for success
-	b := retry.NewFibonacci(time.Second)
-	b = retry.WithMaxDuration(time.Minute*2, b)
-	var statusRes *ssoadmin.DescribeAccountAssignmentCreationStatusOutput
-	err = retry.Do(ctx, b, func(ctx context.Context) (err error) {
-		statusRes, err = p.client.DescribeAccountAssignmentCreationStatus(ctx, &ssoadmin.DescribeAccountAssignmentCreationStatusInput{
-			AccountAssignmentCreationRequestId: res.AccountAssignmentCreationStatus.RequestId,
-			InstanceArn:                        aws.String(p.instanceARN.Get()),
-		})
-		if err != nil {
-			return retry.RetryableError(err)
-		}
-		if statusRes.AccountAssignmentCreationStatus.Status == "IN_PROGRESS" {
-			return retry.RetryableError(errors.New("still in progress"))
-		}
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-	// if the assignment was not successful, return the error and reason
-	if statusRes.AccountAssignmentCreationStatus.FailureReason != nil {
-		return fmt.Errorf("failed creating account assignment: %s", *statusRes.AccountAssignmentCreationStatus.FailureReason)
-	}
+	// // poll the assignment api to check for success
+	// b := retry.NewFibonacci(time.Second)
+	// b = retry.WithMaxDuration(time.Minute*2, b)
+	// var statusRes *ssoadmin.DescribeAccountAssignmentCreationStatusOutput
+	// err = retry.Do(ctx, b, func(ctx context.Context) (err error) {
+	// 	statusRes, err = p.client.DescribeAccountAssignmentCreationStatus(ctx, &ssoadmin.DescribeAccountAssignmentCreationStatusInput{
+	// 		AccountAssignmentCreationRequestId: res.AccountAssignmentCreationStatus.RequestId,
+	// 		InstanceArn:                        aws.String(p.instanceARN.Get()),
+	// 	})
+	// 	if err != nil {
+	// 		return retry.RetryableError(err)
+	// 	}
+	// 	if statusRes.AccountAssignmentCreationStatus.Status == "IN_PROGRESS" {
+	// 		return retry.RetryableError(errors.New("still in progress"))
+	// 	}
+	// 	return nil
+	// })
+	// if err != nil {
+	// 	return err
+	// }
+	// // if the assignment was not successful, return the error and reason
+	// if statusRes.AccountAssignmentCreationStatus.FailureReason != nil {
+	// 	return fmt.Errorf("failed creating account assignment: %s", *statusRes.AccountAssignmentCreationStatus.FailureReason)
+	// }
 
-	return nil
+	// return nil
 }
 
 // Revoke the access by calling the AWS SSO API.

--- a/accesshandler/pkg/providers/aws/sso-v2/access.go
+++ b/accesshandler/pkg/providers/aws/sso-v2/access.go
@@ -22,68 +22,67 @@ type Args struct {
 
 // Grant the access by calling the AWS SSO API.
 func (p *Provider) Grant(ctx context.Context, subject string, args []byte, grantID string) error {
-	return fmt.Errorf("testing")
-	// var a Args
-	// err := json.Unmarshal(args, &a)
-	// if err != nil {
-	// 	return err
-	// }
+	var a Args
+	err := json.Unmarshal(args, &a)
+	if err != nil {
+		return err
+	}
 
-	// // ensure that the account exists in the organization. If it doesn't, calling CreateAccountAssignment
-	// // will silently fail without returning an error.
-	// err = p.ensureAccountExists(ctx, a.AccountID)
-	// if err != nil {
-	// 	return err
-	// }
+	// ensure that the account exists in the organization. If it doesn't, calling CreateAccountAssignment
+	// will silently fail without returning an error.
+	err = p.ensureAccountExists(ctx, a.AccountID)
+	if err != nil {
+		return err
+	}
 
-	// // find the user ID from the provided email address.
-	// user, err := p.getUser(ctx, subject)
-	// if err != nil {
-	// 	return err
-	// }
+	// find the user ID from the provided email address.
+	user, err := p.getUser(ctx, subject)
+	if err != nil {
+		return err
+	}
 
-	// res, err := p.client.CreateAccountAssignment(ctx, &ssoadmin.CreateAccountAssignmentInput{
-	// 	InstanceArn:      aws.String(p.instanceARN.Get()),
-	// 	PermissionSetArn: &a.PermissionSetARN,
-	// 	PrincipalType:    types.PrincipalTypeUser,
-	// 	PrincipalId:      user.UserId,
-	// 	TargetId:         &a.AccountID,
-	// 	TargetType:       types.TargetTypeAwsAccount,
-	// })
-	// if err != nil {
-	// 	return err
-	// }
+	res, err := p.client.CreateAccountAssignment(ctx, &ssoadmin.CreateAccountAssignmentInput{
+		InstanceArn:      aws.String(p.instanceARN.Get()),
+		PermissionSetArn: &a.PermissionSetARN,
+		PrincipalType:    types.PrincipalTypeUser,
+		PrincipalId:      user.UserId,
+		TargetId:         &a.AccountID,
+		TargetType:       types.TargetTypeAwsAccount,
+	})
+	if err != nil {
+		return err
+	}
 
-	// if res.AccountAssignmentCreationStatus.FailureReason != nil {
-	// 	return fmt.Errorf("failed creating account assignment: %s", *res.AccountAssignmentCreationStatus.FailureReason)
-	// }
+	if res.AccountAssignmentCreationStatus.FailureReason != nil {
+		return fmt.Errorf("failed creating account assignment: %s", *res.AccountAssignmentCreationStatus.FailureReason)
+	}
 
-	// // poll the assignment api to check for success
-	// b := retry.NewFibonacci(time.Second)
-	// b = retry.WithMaxDuration(time.Minute*2, b)
-	// var statusRes *ssoadmin.DescribeAccountAssignmentCreationStatusOutput
-	// err = retry.Do(ctx, b, func(ctx context.Context) (err error) {
-	// 	statusRes, err = p.client.DescribeAccountAssignmentCreationStatus(ctx, &ssoadmin.DescribeAccountAssignmentCreationStatusInput{
-	// 		AccountAssignmentCreationRequestId: res.AccountAssignmentCreationStatus.RequestId,
-	// 		InstanceArn:                        aws.String(p.instanceARN.Get()),
-	// 	})
-	// 	if err != nil {
-	// 		return retry.RetryableError(err)
-	// 	}
-	// 	if statusRes.AccountAssignmentCreationStatus.Status == "IN_PROGRESS" {
-	// 		return retry.RetryableError(errors.New("still in progress"))
-	// 	}
-	// 	return nil
-	// })
-	// if err != nil {
-	// 	return err
-	// }
-	// // if the assignment was not successful, return the error and reason
-	// if statusRes.AccountAssignmentCreationStatus.FailureReason != nil {
-	// 	return fmt.Errorf("failed creating account assignment: %s", *statusRes.AccountAssignmentCreationStatus.FailureReason)
-	// }
+	// poll the assignment api to check for success
+	b := retry.NewFibonacci(time.Second)
+	b = retry.WithMaxDuration(time.Minute*2, b)
+	var statusRes *ssoadmin.DescribeAccountAssignmentCreationStatusOutput
+	err = retry.Do(ctx, b, func(ctx context.Context) (err error) {
+		statusRes, err = p.client.DescribeAccountAssignmentCreationStatus(ctx, &ssoadmin.DescribeAccountAssignmentCreationStatusInput{
+			AccountAssignmentCreationRequestId: res.AccountAssignmentCreationStatus.RequestId,
+			InstanceArn:                        aws.String(p.instanceARN.Get()),
+		})
+		if err != nil {
+			return retry.RetryableError(err)
+		}
+		if statusRes.AccountAssignmentCreationStatus.Status == "IN_PROGRESS" {
+			return retry.RetryableError(errors.New("still in progress"))
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	// if the assignment was not successful, return the error and reason
+	if statusRes.AccountAssignmentCreationStatus.FailureReason != nil {
+		return fmt.Errorf("failed creating account assignment: %s", *statusRes.AccountAssignmentCreationStatus.FailureReason)
+	}
 
-	// return nil
+	return nil
 }
 
 // Revoke the access by calling the AWS SSO API.

--- a/accesshandler/pkg/runtime/lambda/granter/granter.go
+++ b/accesshandler/pkg/runtime/lambda/granter/granter.go
@@ -114,6 +114,7 @@ func (g *Granter) HandleRequest(ctx context.Context, in InputEvent) (Output, err
 	if err != nil {
 		log.Errorf("error while handling granter event", "error", err.Error(), "event", in)
 		grant.Status = types.GrantStatusERROR
+		grant.End = grant.Start
 		eventErr := eventsBus.Put(ctx, gevent.GrantFailed{Grant: grant, Reason: err.Error()})
 		if eventErr != nil {
 			return Output{}, errors.Wrapf(err, "failed to emit event, emit error: %s", eventErr.Error())

--- a/accesshandler/pkg/runtime/lambda/granter/granter.go
+++ b/accesshandler/pkg/runtime/lambda/granter/granter.go
@@ -114,7 +114,7 @@ func (g *Granter) HandleRequest(ctx context.Context, in InputEvent) (Output, err
 	if err != nil {
 		log.Errorf("error while handling granter event", "error", err.Error(), "event", in)
 		grant.Status = types.GrantStatusERROR
-		grant.End = grant.Start
+
 		eventErr := eventsBus.Put(ctx, gevent.GrantFailed{Grant: grant, Reason: err.Error()})
 		if eventErr != nil {
 			return Output{}, errors.Wrapf(err, "failed to emit event, emit error: %s", eventErr.Error())

--- a/pkg/access/request.go
+++ b/pkg/access/request.go
@@ -196,10 +196,13 @@ func (r *Request) DDBKeys() (ddb.Keys, error) {
 	// - PENDING asap requests should have MAXIMUM endtime
 	// - Declined and Cancelled requests should have an end time = createdAt so they get a somewhat natural order in the results
 	// - REVOKED grants should have end time = created at
+	// - ERROR grants should have end times = created at
 	end := r.CreatedAt
 	if r.Status == APPROVED || r.Status == PENDING {
 		if r.Grant != nil {
-			if r.Grant.Status != ac_types.GrantStatusREVOKED {
+			//any grant status other than revoked or error should be equal to grant.end.
+			//this is to make sure the error and revoke grants are pushed to the past column in the frontend
+			if !(r.Grant.Status == ac_types.GrantStatusREVOKED || r.Grant.Status == ac_types.GrantStatusERROR) {
 				end = r.Grant.End
 			}
 		} else if r.IsScheduled() {

--- a/pkg/access/request.go
+++ b/pkg/access/request.go
@@ -199,7 +199,7 @@ func (r *Request) DDBKeys() (ddb.Keys, error) {
 	end := r.CreatedAt
 	if r.Status == APPROVED || r.Status == PENDING {
 		if r.Grant != nil {
-			if r.Grant.Status != ac_types.GrantStatusREVOKED {
+			if r.Grant.Status != ac_types.GrantStatusREVOKED || r.Grant.Status != ac_types.GrantStatusERROR {
 				end = r.Grant.End
 			}
 		} else if r.IsScheduled() {

--- a/pkg/access/request.go
+++ b/pkg/access/request.go
@@ -199,7 +199,7 @@ func (r *Request) DDBKeys() (ddb.Keys, error) {
 	end := r.CreatedAt
 	if r.Status == APPROVED || r.Status == PENDING {
 		if r.Grant != nil {
-			if r.Grant.Status != ac_types.GrantStatusREVOKED || r.Grant.Status != ac_types.GrantStatusERROR {
+			if r.Grant.Status != ac_types.GrantStatusREVOKED {
 				end = r.Grant.End
 			}
 		} else if r.IsScheduled() {

--- a/pkg/access/request_test.go
+++ b/pkg/access/request_test.go
@@ -85,7 +85,7 @@ func TestRequestMarshalDDB(t *testing.T) {
 			want: `{"PK":"ACCESS_REQUEST#","SK":"req_28w2Eebt2Q8nFQJ2dKa1FTE9X0J","GSI1PK":"ACCESS_REQUEST#user","GSI1SK":"req_28w2Eebt2Q8nFQJ2dKa1FTE9X0J","GSI2PK":"ACCESS_REQUEST#APPROVED","GSI2SK":"user#req_28w2Eebt2Q8nFQJ2dKa1FTE9X0J","GSI3PK":"ACCESS_REQUEST#user","GSI3SK":"2022-01-01T10:01:00Z","GSI4PK":"ACCESS_REQUEST#user#rul_123","GSI4SK":"2022-01-01T10:01:00Z"}`,
 		},
 		{
-			name: "error grant in the past",
+			name: "error'd grant end time in the past",
 			give: Request{
 				ID:          "req_28w2Eebt2Q8nFQJ2dKa1FTE9X0J",
 				RequestedBy: "user",

--- a/pkg/access/request_test.go
+++ b/pkg/access/request_test.go
@@ -84,6 +84,29 @@ func TestRequestMarshalDDB(t *testing.T) {
 			},
 			want: `{"PK":"ACCESS_REQUEST#","SK":"req_28w2Eebt2Q8nFQJ2dKa1FTE9X0J","GSI1PK":"ACCESS_REQUEST#user","GSI1SK":"req_28w2Eebt2Q8nFQJ2dKa1FTE9X0J","GSI2PK":"ACCESS_REQUEST#APPROVED","GSI2SK":"user#req_28w2Eebt2Q8nFQJ2dKa1FTE9X0J","GSI3PK":"ACCESS_REQUEST#user","GSI3SK":"2022-01-01T10:01:00Z","GSI4PK":"ACCESS_REQUEST#user#rul_123","GSI4SK":"2022-01-01T10:01:00Z"}`,
 		},
+		{
+			name: "error grant in the past",
+			give: Request{
+				ID:          "req_28w2Eebt2Q8nFQJ2dKa1FTE9X0J",
+				RequestedBy: "user",
+				Rule:        "rul_123",
+				RuleVersion: "2022-01-01T10:00:00Z",
+				Status:      APPROVED,
+				Data: RequestData{
+					Reason: &reason,
+				},
+				RequestedTiming: Timing{
+					Duration: time.Minute * 5,
+				},
+				CreatedAt: time.Date(2022, 1, 1, 10, 0, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2022, 1, 1, 10, 0, 0, 0, time.UTC),
+				Grant: &Grant{
+					Status: types.GrantStatusERROR,
+					End:    time.Date(2022, 1, 1, 10, 1, 0, 0, time.UTC),
+				},
+			},
+			want: `{"PK":"ACCESS_REQUEST#","SK":"req_28w2Eebt2Q8nFQJ2dKa1FTE9X0J","GSI1PK":"ACCESS_REQUEST#user","GSI1SK":"req_28w2Eebt2Q8nFQJ2dKa1FTE9X0J","GSI2PK":"ACCESS_REQUEST#APPROVED","GSI2SK":"user#req_28w2Eebt2Q8nFQJ2dKa1FTE9X0J","GSI3PK":"ACCESS_REQUEST#user","GSI3SK":"2022-01-01T10:00:00Z","GSI4PK":"ACCESS_REQUEST#user#rul_123","GSI4SK":"2022-01-01T10:00:00Z"}`,
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/eventhandler/eventhandler.go
+++ b/pkg/eventhandler/eventhandler.go
@@ -82,6 +82,8 @@ func (n *EventHandler) HandleGrantEvent(ctx context.Context, log *zap.SugaredLog
 		}
 		requestEvent = access.NewGrantFailedEvent(gq.Result.ID, event.Time, oldStatus, newStatus, grantFailedEvent.Reason)
 		log.Infow("inserting request event for grant failed")
+		//if failed then we want to update the end time of the grant to be completed
+		gq.Result.Grant.End = event.Time
 	} else {
 		requestEvent = access.NewGrantStatusChangeEvent(gq.Result.ID, event.Time, nil, oldStatus, newStatus)
 		log.Infow("inserting request event for grant status change")

--- a/pkg/eventhandler/eventhandler.go
+++ b/pkg/eventhandler/eventhandler.go
@@ -82,8 +82,7 @@ func (n *EventHandler) HandleGrantEvent(ctx context.Context, log *zap.SugaredLog
 		}
 		requestEvent = access.NewGrantFailedEvent(gq.Result.ID, event.Time, oldStatus, newStatus, grantFailedEvent.Reason)
 		log.Infow("inserting request event for grant failed")
-		//if failed then we want to update the end time of the grant to be completed
-		gq.Result.Grant.End = event.Time
+
 	} else {
 		requestEvent = access.NewGrantStatusChangeEvent(gq.Result.ID, event.Time, nil, oldStatus, newStatus)
 		log.Infow("inserting request event for grant status change")

--- a/pkg/service/accesssvc/cancel.go
+++ b/pkg/service/accesssvc/cancel.go
@@ -60,6 +60,7 @@ func canCancel(opts CancelRequestOpts, request access.Request) bool {
 	return opts.CancellerID == request.RequestedBy
 }
 
+// A request can be cancelled if
 func isCancellable(request access.Request) bool {
-	return request.Status == access.PENDING
+	return request.Status == access.PENDING || (request.Grant == nil && request.Status != access.CANCELLED)
 }

--- a/pkg/service/accesssvc/cancel.go
+++ b/pkg/service/accesssvc/cancel.go
@@ -62,5 +62,5 @@ func canCancel(opts CancelRequestOpts, request access.Request) bool {
 
 // A request can be cancelled if
 func isCancellable(request access.Request) bool {
-	return request.Status == access.PENDING || (request.Grant == nil && request.Status != access.CANCELLED)
+	return request.Status == access.PENDING || request.Grant == nil && request.Status != access.CANCELLED
 }

--- a/pkg/service/accesssvc/cancel_test.go
+++ b/pkg/service/accesssvc/cancel_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/benbjohnson/clock"
 	"github.com/common-fate/ddb/ddbmock"
+	"github.com/common-fate/granted-approvals/accesshandler/pkg/types"
 	"github.com/common-fate/granted-approvals/pkg/access"
 	accessMocks "github.com/common-fate/granted-approvals/pkg/service/accesssvc/mocks"
 	"github.com/common-fate/granted-approvals/pkg/storage"
@@ -50,7 +51,7 @@ func TestCancelRequest(t *testing.T) {
 			wantErr: ErrUserNotAuthorized,
 		},
 		{
-			name: "request not pending",
+			name: "active request not pending",
 			givenCancelRequest: CancelRequestOpts{
 				CancellerID: "abcd",
 				RequestID:   "req123",
@@ -58,6 +59,44 @@ func TestCancelRequest(t *testing.T) {
 			getRequestResponse: &access.Request{
 				RequestedBy: "abcd",
 				Status:      access.APPROVED,
+				Grant:       &access.Grant{Status: types.GrantStatusACTIVE},
+			},
+			wantErr: ErrRequestCannotBeCancelled,
+		},
+		{
+			name: "failed grant auto approved request can be cancelled",
+			givenCancelRequest: CancelRequestOpts{
+				CancellerID: "abcd",
+				RequestID:   "req123",
+			},
+			getRequestResponse: &access.Request{
+				RequestedBy: "abcd",
+				Status:      access.APPROVED,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "cancelled request cannot be cancelled",
+			givenCancelRequest: CancelRequestOpts{
+				CancellerID: "abcd",
+				RequestID:   "req123",
+			},
+			getRequestResponse: &access.Request{
+				RequestedBy: "abcd",
+				Status:      access.CANCELLED,
+			},
+			wantErr: ErrRequestCannotBeCancelled,
+		},
+		{
+			name: "revoked grants cannot be cancelled",
+			givenCancelRequest: CancelRequestOpts{
+				CancellerID: "abcd",
+				RequestID:   "req123",
+			},
+			getRequestResponse: &access.Request{
+				RequestedBy: "abcd",
+				Status:      access.APPROVED,
+				Grant:       &access.Grant{Status: types.GrantStatusREVOKED},
 			},
 			wantErr: ErrRequestCannotBeCancelled,
 		},

--- a/web/src/components/Request.tsx
+++ b/web/src/components/Request.tsx
@@ -720,11 +720,12 @@ export const RequestCancelButton: React.FC = () => {
     <ButtonGroup variant="outline" size="sm">
       {!request && <Skeleton rounded="full" w="64px" h="32px" />}
       {/* allow to cancel requests if the grant has not been created yet */}
-      {request?.status === "PENDING" && request.grant?.status == "PENDING" || request?.grant == undefined && (
-        <Button rounded="full" onClick={handleCancel}>
-          Cancel
-        </Button>
-      )}
+      {(request?.status === "PENDING" && request.grant?.status == "PENDING") ||
+        (request?.grant == undefined && (
+          <Button rounded="full" onClick={handleCancel}>
+            Cancel
+          </Button>
+        ))}
     </ButtonGroup>
   );
 };

--- a/web/src/components/Request.tsx
+++ b/web/src/components/Request.tsx
@@ -715,19 +715,23 @@ export const RequestCancelButton: React.FC = () => {
       });
     }
   };
-
-  return (
-    <ButtonGroup variant="outline" size="sm">
-      {!request && <Skeleton rounded="full" w="64px" h="32px" />}
-      {/* allow to cancel requests if the grant has not been created yet */}
-      {((request?.status === "PENDING" && request.grant?.status == "PENDING") ||
-        (request?.grant == undefined) && (
-          <Button rounded="full" onClick={handleCancel}>
-            Cancel
-          </Button>
-        ))}
-    </ButtonGroup>
-  );
+  // only display cancel if request is pending or is grant is still undefined
+  if (
+    (request?.status === "PENDING" && request.grant?.status == "PENDING") ||
+    request?.grant == undefined
+  ) {
+    return (
+      <ButtonGroup variant="outline" size="sm">
+        {!request && <Skeleton rounded="full" w="64px" h="32px" />}
+        <Button rounded="full" onClick={handleCancel}>
+          Cancel
+        </Button>
+        ))
+      </ButtonGroup>
+    );
+  } else {
+    return <></>
+  }
 };
 
 interface RevokeButtonsProps {

--- a/web/src/components/Request.tsx
+++ b/web/src/components/Request.tsx
@@ -719,7 +719,8 @@ export const RequestCancelButton: React.FC = () => {
   return (
     <ButtonGroup variant="outline" size="sm">
       {!request && <Skeleton rounded="full" w="64px" h="32px" />}
-      {request?.status === "PENDING" && request.grant?.status == "PENDING" && (
+      {/* allow to cancel requests if the grant has not been created yet */}
+      {request?.status === "PENDING" && request.grant?.status == "PENDING" || request?.grant == undefined && (
         <Button rounded="full" onClick={handleCancel}>
           Cancel
         </Button>

--- a/web/src/components/Request.tsx
+++ b/web/src/components/Request.tsx
@@ -720,8 +720,8 @@ export const RequestCancelButton: React.FC = () => {
     <ButtonGroup variant="outline" size="sm">
       {!request && <Skeleton rounded="full" w="64px" h="32px" />}
       {/* allow to cancel requests if the grant has not been created yet */}
-      {(request?.status === "PENDING" && request.grant?.status == "PENDING") ||
-        (request?.grant == undefined && (
+      {((request?.status === "PENDING" && request.grant?.status == "PENDING") ||
+        (request?.grant == undefined) && (
           <Button rounded="full" onClick={handleCancel}>
             Cancel
           </Button>

--- a/web/src/components/Request.tsx
+++ b/web/src/components/Request.tsx
@@ -730,7 +730,7 @@ export const RequestCancelButton: React.FC = () => {
       </ButtonGroup>
     );
   } else {
-    return <></>
+    return <></>;
   }
 };
 


### PR DESCRIPTION
Updates cancel logic to be able to cancel requests when the underlying grant has failed