### PR TITLE
Josh/app 51 listcurrentaccessrules always return an

### DIFF
--- a/pkg/storage/list_current_rules.go
+++ b/pkg/storage/list_current_rules.go
@@ -17,7 +17,7 @@ func (l *ListCurrentAccessRules) BuildQuery() (*dynamodb.QueryInput, error) {
 		IndexName:              &keys.IndexNames.GSI2,
 		KeyConditionExpression: aws.String("GSI2PK = :pk"),
 		ExpressionAttributeValues: map[string]types.AttributeValue{
-			":pk": &types.AttributeValueMemberS{Value: keys.AccessRule.PK1},
+			":pk": &types.AttributeValueMemberS{Value: keys.AccessRule.GSI2PK},
 		},
 	}
 	return &qi, nil

--- a/pkg/storage/list_current_rules_test.go
+++ b/pkg/storage/list_current_rules_test.go
@@ -1,0 +1,26 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/common-fate/ddb/ddbtest"
+	"github.com/common-fate/granted-approvals/pkg/rule"
+	"github.com/common-fate/granted-approvals/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListCurrentAccessRules(t *testing.T) {
+	db := newTestingStorage(t)
+
+	current := rule.TestAccessRule()
+	archived := current
+	archived.Current = false
+	current.Version = types.NewVersionID()
+	ddbtest.PutFixtures(t, db, []*rule.AccessRule{&current, &archived})
+	q := &ListCurrentAccessRules{}
+	_, err := db.Query(context.TODO(), q)
+	assert.NoError(t, err)
+	assert.NotContains(t, q.Result, archived)
+	assert.Contains(t, q.Result, current)
+}


### PR DESCRIPTION
Fixes a bug in the query for current access rules where it was using the wrong PK field value.
Also added a new test to cover this