### PR TITLE
wait for scheduled start time for instructions

### DIFF
--- a/web/src/components/Request.tsx
+++ b/web/src/components/Request.tsx
@@ -292,13 +292,31 @@ export const RequestAccessInstructions: React.FC = () => {
 
   useEffect(() => {
     if (reqData?.grant?.status == "PENDING") {
-      setRefreshInterval(2000);
+      if (
+        reqData?.timing.startTime &&
+        Date.parse(reqData.timing.startTime) > new Date().valueOf()
+      ) {
+        // This should make it refresh at least once just after its scheduled start time
+        setRefreshInterval(
+          Date.parse(reqData.timing.startTime) - new Date().valueOf() + 100
+        );
+      } else {
+        setRefreshInterval(2000);
+      }
     } else {
       setRefreshInterval(0);
     }
   }, [reqData]);
 
   if (!data || !data.instructions) {
+    return null;
+  }
+
+  // Don't attempt to load a shceduled request until start time
+  if (
+    reqData?.timing.startTime &&
+    Date.parse(reqData.timing.startTime) > new Date().valueOf()
+  ) {
     return null;
   }
 

--- a/web/src/components/Request.tsx
+++ b/web/src/components/Request.tsx
@@ -312,7 +312,7 @@ export const RequestAccessInstructions: React.FC = () => {
     return null;
   }
 
-  // Don't attempt to load a shceduled request until start time
+  // Don't attempt to load a scheduled request until start time
   if (
     reqData?.timing.startTime &&
     Date.parse(reqData.timing.startTime) > new Date().valueOf()


### PR DESCRIPTION
This hides the instructions loading animation until the scheduled start time for a scheduled request, it sets teh refresh interval to automatically refresh when the start time passes so you can leave the page running until its ready and then it will load automatically