### PR TITLE
fix bracket characters in frontend

### DIFF
--- a/web/src/components/CFTimelineRow.tsx
+++ b/web/src/components/CFTimelineRow.tsx
@@ -1,4 +1,15 @@
-import { Box, Flex, Text, Tooltip, useColorModeValue } from "@chakra-ui/react";
+import {
+  Box,
+  Flex,
+  Popover,
+  PopoverArrow,
+  PopoverBody,
+  PopoverCloseButton,
+  PopoverContent,
+  PopoverTrigger,
+  Text,
+  useColorModeValue,
+} from "@chakra-ui/react";
 import { formatDistanceToNowStrict } from "date-fns";
 import React from "react";
 
@@ -64,11 +75,29 @@ export const CFTimelineRow = ({
         <Text fontSize="sm" color={textColor} fontWeight="bold">
           {header}
         </Text>
-        <Tooltip label={timestamp.toString()}>
-          <Text fontSize="sm" color="gray.400" fontWeight="normal">
-            {formatDistanceToNowStrict(timestamp, { addSuffix: true })}
-          </Text>
-        </Tooltip>
+        <Box>
+          <Popover>
+            <PopoverTrigger>
+              <Text
+                flexGrow={0}
+                tabIndex={0}
+                as="button"
+                display={"inline-block"}
+                textAlign="left"
+                fontSize="sm"
+                color="gray.400"
+                fontWeight="normal"
+              >
+                {formatDistanceToNowStrict(timestamp, { addSuffix: true })}
+              </Text>
+            </PopoverTrigger>
+            <PopoverContent>
+              <PopoverArrow />
+              <PopoverCloseButton />
+              <PopoverBody>{timestamp.toString()}</PopoverBody>
+            </PopoverContent>
+          </Popover>
+        </Box>
       </Flex>
     </Flex>
   );

--- a/web/src/components/Request.tsx
+++ b/web/src/components/Request.tsx
@@ -748,7 +748,7 @@ export const RequestCancelButton: React.FC = () => {
       </ButtonGroup>
     );
   } else {
-    return <></>;
+    return null;
   }
 };
 

--- a/web/src/components/Request.tsx
+++ b/web/src/components/Request.tsx
@@ -745,7 +745,6 @@ export const RequestCancelButton: React.FC = () => {
         <Button rounded="full" onClick={handleCancel}>
           Cancel
         </Button>
-        ))
       </ButtonGroup>
     );
   } else {


### PR DESCRIPTION
Some small frontend UI tidy-ups.

We were displaying `))` in the frontend when access instructions are loading, which has been removed.

Extends on @alexjurkiewicz's work in #274 to show relative timestamps of audit trail entries. I've swapped the `Tooltip` component for a `Popover` to improve accessibility and make it possible to select the extact timestamp text from the frontend UI.

Before:
<img width="422" alt="image" src="https://user-images.githubusercontent.com/17420369/193302926-92968c76-922e-4e21-9026-8c87773e938e.png">

After:
<img width="559" alt="image" src="https://user-images.githubusercontent.com/17420369/193302672-4eced8db-239a-47b7-87a5-24c4b4e2f12a.png">

