### PR TITLE
fix 'copy' button not working on safari

### DIFF
--- a/web/src/components/CodeInstruction.tsx
+++ b/web/src/components/CodeInstruction.tsx
@@ -27,7 +27,62 @@ export const CFCode: React.FC<CProps> = (props) => {
     </Code>
   );
 };
-export const CodeInstruction: React.FC<CodeProps> = (props) => {
+
+export interface CFCodeMultilineProps {
+  text: string;
+}
+
+/**
+ * A multiline preformatted code block with a copy button.
+ */
+export const CFCodeMultiline: React.FC<CFCodeMultilineProps> = ({ text }) => {
+  const { hasCopied, onCopy } = useClipboard(text);
+
+  return (
+    <Stack>
+      <Code
+        padding={0}
+        bg="white"
+        borderRadius="8px"
+        borderColor="neutrals.300"
+        borderWidth="1px"
+      >
+        <Flex
+          borderColor="neutrals.300"
+          borderBottomWidth="1px"
+          py="8px"
+          px="16px"
+          minH="36px"
+        >
+          <Spacer />
+          <IconButton
+            variant="ghost"
+            h="20px"
+            icon={hasCopied ? <CheckIcon /> : <CopyIcon />}
+            onClick={onCopy}
+            aria-label={"Copy"}
+          />
+        </Flex>
+        <Text
+          overflowX="auto"
+          color="neutrals.700"
+          padding={4}
+          whiteSpace="pre-wrap"
+        >
+          {text}
+        </Text>
+      </Code>
+    </Stack>
+  );
+};
+
+/**
+ * This component should only be used with react-markdown.
+ *
+ * Use CFMultilineCode if you're working with regular React components
+ * rather than markdown.
+ */
+export const CFReactMarkownCode: React.FC<CodeProps> = (props) => {
   const { children, node, ...rest } = props;
   let value = "";
   if (

--- a/web/src/components/Request.tsx
+++ b/web/src/components/Request.tsx
@@ -51,7 +51,7 @@ import { useUser } from "../utils/context/userContext";
 import { durationStringHoursMinutes } from "../utils/durationString";
 import { renderTiming } from "../utils/renderTiming";
 import { userName } from "../utils/userName";
-import { CodeInstruction } from "./CodeInstruction";
+import { CFReactMarkownCode } from "./CodeInstruction";
 import { CopyableOption } from "./CopyableOption";
 import { ProviderIcon } from "./icons/providerIcon";
 import EditRequestTimeModal from "./modals/EditRequestTimeModal";
@@ -343,7 +343,7 @@ export const RequestAccessInstructions: React.FC = () => {
                 {props.children}
               </Text>
             ),
-            code: CodeInstruction,
+            code: CFReactMarkownCode,
           }}
         >
           {data.instructions}

--- a/web/src/pages/access/index.tsx
+++ b/web/src/pages/access/index.tsx
@@ -2,7 +2,7 @@ import { InfoIcon } from "@chakra-ui/icons";
 import { Box, Center, Flex, Spinner, Text } from "@chakra-ui/react";
 import { useEffect } from "react";
 import { Link, MakeGenerics, useNavigate, useSearch } from "react-location";
-import { CodeInstruction } from "../../components/CodeInstruction";
+import { CFCodeMultiline } from "../../components/CodeInstruction";
 import { UserLayout } from "../../components/Layout";
 import { OnboardingCard } from "../../components/OnboardingCard";
 import { SelectRuleTable } from "../../components/tables/SelectRuleTable";
@@ -73,12 +73,8 @@ const Access = () => {
           {data && data.length == 0 && (
             <>
               We couldn't find any access rules for you
-              <CodeInstruction
-                mt={2}
-                textAlign="left"
-                inline={false}
-                // @ts-ignore
-                children={`Access rule not found, details below:
+              <CFCodeMultiline
+                text={`Access rule not found, details below:
 ${JSON.stringify(search, null, 2)}`}
               />
               <Flex _hover={{ textDecor: "underline" }} mt={12}>

--- a/web/src/pages/access/index.tsx
+++ b/web/src/pages/access/index.tsx
@@ -72,7 +72,7 @@ const Access = () => {
           )}
           {data && data.length == 0 && (
             <>
-              We couldn't find any access rules for you
+              <Text mb={2}>We couldn't find any access rules for you</Text>
               <CFCodeMultiline
                 text={`Access rule not found, details below:
 ${JSON.stringify(search, null, 2)}`}

--- a/web/src/pages/admin/providers/setup/[id]/finish.tsx
+++ b/web/src/pages/admin/providers/setup/[id]/finish.tsx
@@ -16,7 +16,7 @@ import { Link, Navigate, useMatch } from "react-location";
 import ReactMarkdown from "react-markdown";
 import {
   CFCode,
-  CodeInstruction,
+  CFReactMarkownCode,
 } from "../../../../../components/CodeInstruction";
 import { AdminLayout } from "../../../../../components/Layout";
 import { useGetProvidersetup } from "../../../../../utils/backend-client/admin/admin";
@@ -166,7 +166,7 @@ const Page = () => {
                         {props.children}
                       </Text>
                     ),
-                    code: CodeInstruction,
+                    code: CFReactMarkownCode,
                   }}
                 >
                   {gdeployCommand}
@@ -191,7 +191,7 @@ const Page = () => {
                         {props.children}
                       </Text>
                     ),
-                    code: CodeInstruction,
+                    code: CFReactMarkownCode,
                   }}
                 >
                   {"```\ngdeploy update\n```"}

--- a/web/src/pages/admin/providers/setup/[id]/index.tsx
+++ b/web/src/pages/admin/providers/setup/[id]/index.tsx
@@ -54,7 +54,7 @@ import { Sticky, StickyContainer } from "react-sticky";
 import useWindowSize from "react-use/lib/useWindowSize";
 import {
   CFCode,
-  CodeInstruction,
+  CFReactMarkownCode,
 } from "../../../../../components/CodeInstruction";
 import { ConnectorArrow } from "../../../../../components/ConnectorArrow";
 import { ExpandingImage } from "../../../../../components/ExpandingImage";
@@ -550,7 +550,7 @@ const StepDisplay: React.FC<StepDisplayProps> = ({
                       {props.children}
                     </OrderedList>
                   ),
-                  code: CodeInstruction,
+                  code: CFReactMarkownCode,
                   img: (props) => <ExpandingImage {...props} />,
                 }}
               >


### PR DESCRIPTION
We were reusing the `CodeInstruction` component for rendering markdown as well as in regular React components. This PR separates that out to avoid an issue we were running into on Safari where clicking the copy icon would cause an alert like this to appear:

<img width="706" alt="image" src="https://user-images.githubusercontent.com/17420369/193306515-b3547b5b-61bc-4c53-8cae-f06923994c79.png">
