### PR TITLE
only make the popover trigger on info icon

### DIFF
--- a/web/src/components/InfoOption.tsx
+++ b/web/src/components/InfoOption.tsx
@@ -21,22 +21,22 @@ export const InfoOption: React.FC<{ label: string; value: string }> = ({
   return (
     <WrapItem>
       <Popover>
-        <PopoverTrigger>
-          <HStack
-            textStyle={"Body/Small"}
-            rounded="full"
-            bg="neutrals.300"
-            py={1}
-            px={4}
-          >
-            <Text>{label}</Text>{" "}
+        <HStack
+          textStyle={"Body/Small"}
+          rounded="full"
+          bg="neutrals.300"
+          py={1}
+          px={4}
+        >
+          <Text>{label}</Text>{" "}
+          <PopoverTrigger>
             <InfoIcon
               cursor={"pointer"}
               h="10px"
               color={colors.neutrals[600]}
             />
-          </HStack>
-        </PopoverTrigger>
+          </PopoverTrigger>
+        </HStack>
         <PopoverContent>
           <PopoverArrow />
           <PopoverCloseButton />


### PR DESCRIPTION
The popover we've implemented steals focus which makes selection the chip UI text very difficult.

Before: https://www.loom.com/share/d3cd08e474d2466ba2b8b11b98f36190

After: https://www.loom.com/share/5096a53be3464775a4303028af0b0fc2