### PR TITLE
CF-180: Grant Error Message

### DIFF
--- a/accesshandler/pkg/providers/aws/ecs-shell-sso/validate.go
+++ b/accesshandler/pkg/providers/aws/ecs-shell-sso/validate.go
@@ -34,7 +34,7 @@ func (p *Provider) ValidateGrant() providers.GrantValidationSteps {
 
 	return map[string]providers.GrantValidationStep{
 		"user-exists-in-aws-sso": {
-			Name: "The user must exist in the AWS SSO instance",
+			UserErrorMessage: "The user does not exist in the AWS SSO instance",
 			Run: func(ctx context.Context, subject string, args []byte) diagnostics.Logs {
 				var a Args
 				err := json.Unmarshal(args, &a)
@@ -62,7 +62,7 @@ func (p *Provider) ValidateGrant() providers.GrantValidationSteps {
 			},
 		},
 		"account-exists": {
-			Name: "The account should exist",
+			UserErrorMessage: "We could not find your AWS Account",
 			Run: func(ctx context.Context, subject string, args []byte) diagnostics.Logs {
 				var a Args
 				err := json.Unmarshal(args, &a)
@@ -78,7 +78,7 @@ func (p *Provider) ValidateGrant() providers.GrantValidationSteps {
 			},
 		},
 		"cluster-exists": {
-			Name: "The targeted cluster should exist",
+			UserErrorMessage: "We could not find the target cluster specified",
 			Run: func(ctx context.Context, subject string, args []byte) diagnostics.Logs {
 				var a Args
 				err := json.Unmarshal(args, &a)

--- a/accesshandler/pkg/providers/aws/eks-roles-sso/validate.go
+++ b/accesshandler/pkg/providers/aws/eks-roles-sso/validate.go
@@ -16,7 +16,7 @@ import (
 func (p *Provider) ValidateGrant() providers.GrantValidationSteps {
 	return map[string]providers.GrantValidationStep{
 		"user-exists-in-aws-sso": {
-			Name: "The user must exist in the AWS SSO instance",
+			UserErrorMessage: "We could not find your user in AWS SSO",
 			Run: func(ctx context.Context, subject string, args []byte) diagnostics.Logs {
 				var a Args
 				err := json.Unmarshal(args, &a)

--- a/accesshandler/pkg/providers/aws/sso-v2/validate.go
+++ b/accesshandler/pkg/providers/aws/sso-v2/validate.go
@@ -21,7 +21,7 @@ func (p *Provider) ValidateGrant() providers.GrantValidationSteps {
 
 	return map[string]providers.GrantValidationStep{
 		"user-exists-in-AWS-SSO": {
-			Name: "User must exist in AWS SSO",
+			UserErrorMessage: "We could not find your user in AWS SSO",
 			Run: func(ctx context.Context, subject string, args []byte) diagnostics.Logs {
 				var a Args
 				err := json.Unmarshal(args, &a)
@@ -50,7 +50,7 @@ func (p *Provider) ValidateGrant() providers.GrantValidationSteps {
 			},
 		},
 		"permission-set-should-exist": {
-			Name: "Permission set must exist in AWS SSO",
+			UserErrorMessage: "We could not find the permission set in AWS SSO",
 			Run: func(ctx context.Context, subject string, args []byte) diagnostics.Logs {
 				var a Args
 				err := json.Unmarshal(args, &a)
@@ -68,7 +68,7 @@ func (p *Provider) ValidateGrant() providers.GrantValidationSteps {
 			},
 		},
 		"aws-account-exists": {
-			Name: "AWS account must exist in the AWS organization",
+			UserErrorMessage: "We could not find the AWS account in your organization",
 			Run: func(ctx context.Context, subject string, args []byte) diagnostics.Logs {
 				var a Args
 				err := json.Unmarshal(args, &a)

--- a/accesshandler/pkg/providers/azure/ad/validate.go
+++ b/accesshandler/pkg/providers/azure/ad/validate.go
@@ -25,7 +25,7 @@ type ADErr struct {
 func (p *Provider) ValidateGrant() providers.GrantValidationSteps {
 	return map[string]providers.GrantValidationStep{
 		"user-exists-in-azure-ad": {
-			Name: "The user must exist in the Azure AD tenancy",
+			UserErrorMessage: "We couldn't find a matching user account in Azure AD",
 			Run: func(ctx context.Context, subject string, args []byte) diagnostics.Logs {
 				var a Args
 				err := json.Unmarshal(args, &a)
@@ -52,7 +52,7 @@ func (p *Provider) ValidateGrant() providers.GrantValidationSteps {
 			},
 		},
 		"group-exists-in-azure-ad": {
-			Name: "The group must exist in the Azure AD tenancy",
+			UserErrorMessage: "We couldn't find a matching group in Azure AD",
 			Run: func(ctx context.Context, subject string, args []byte) diagnostics.Logs {
 				var a Args
 				err := json.Unmarshal(args, &a)

--- a/accesshandler/pkg/providers/grant-validation.go
+++ b/accesshandler/pkg/providers/grant-validation.go
@@ -2,11 +2,9 @@ package providers
 
 import (
 	"context"
-	"errors"
 	"sync"
 
 	"github.com/common-fate/granted-approvals/accesshandler/pkg/diagnostics"
-	"github.com/hashicorp/go-multierror"
 )
 
 type GrantValidationResult struct {
@@ -17,8 +15,8 @@ type GrantValidationSteps map[string]GrantValidationStep
 
 type GrantValidationResults map[string]GrantValidationResult
 type GrantValidationStep struct {
-	Name string
-	Run  func(ctx context.Context, subject string, args []byte) diagnostics.Logs
+	Run              func(ctx context.Context, subject string, args []byte) diagnostics.Logs
+	UserErrorMessage string
 }
 
 // Run runs each of the validation steps in parallel then returns the results
@@ -35,7 +33,7 @@ func (s GrantValidationSteps) Run(ctx context.Context, subject string, args []by
 			func(key string, value GrantValidationStep, logs diagnostics.Logs) {
 				mu.Lock()
 				defer mu.Unlock()
-				validationResults[key] = GrantValidationResult{Logs: logs, Name: v.Name}
+				validationResults[key] = GrantValidationResult{Logs: logs, Name: v.UserErrorMessage}
 			}(k, v, logs)
 			wg.Done()
 		}()
@@ -58,11 +56,11 @@ func (r GrantValidationResults) FailureMessage() string {
 	if !r.Failed() {
 		return ""
 	}
-	var message error
+	var message string
 	for _, v := range r {
 		if !v.Logs.HasSucceeded() {
-			message = multierror.Append(message, errors.New(v.Name))
+			message = message + v.Name + "\n"
 		}
 	}
-	return message.Error()
+	return message
 }

--- a/accesshandler/pkg/providers/grant-validation_test.go
+++ b/accesshandler/pkg/providers/grant-validation_test.go
@@ -22,7 +22,7 @@ func TestGrantValidationsResults(t *testing.T) {
 	}}}
 
 	assert.True(t, a.Failed())
-	assert.Equal(t, "1 error occurred:\n\t* a\n\n", a.FailureMessage())
+	assert.Equal(t, "a\n", a.FailureMessage())
 
 	assert.False(t, b.Failed())
 	assert.Equal(t, "", b.FailureMessage())

--- a/accesshandler/pkg/providers/okta/validate.go
+++ b/accesshandler/pkg/providers/okta/validate.go
@@ -20,7 +20,7 @@ func (p *Provider) ValidateGrant() providers.GrantValidationSteps {
 	return map[string]providers.GrantValidationStep{
 
 		"user-exists-in-okta": {
-			Name: "The user must exist in the Okta tenancy",
+			UserErrorMessage: "We couldn't find a matching user account for you in Okta",
 			Run: func(ctx context.Context, subject string, args []byte) diagnostics.Logs {
 
 				_, _, err := p.client.User.GetUser(ctx, subject)
@@ -34,7 +34,7 @@ func (p *Provider) ValidateGrant() providers.GrantValidationSteps {
 		},
 
 		"group-exists-in-okta": {
-			Name: "The group must exist in the the Okta tenancy",
+			UserErrorMessage: "We couldn't find a matching group in Okta",
 			Run: func(ctx context.Context, subject string, args []byte) diagnostics.Logs {
 				var a Args
 				err := json.Unmarshal(args, &a)


### PR DESCRIPTION
UDE = "1 error occurred" doesn't add any info
UDE = "*" character as a dot point makes Granted Approvals feel unpolished

- [x] IO = add a UserErrorMessage field to the GrantValidationStep struct and fill this out for our providers
- [x] IO = update the API to return the UserErrorMessage rather than the Name 

<img width="408" alt="image" src="https://user-images.githubusercontent.com/21688404/194829521-e01488ec-8fe9-4434-8a58-13b87e26b366.png">
