### PR TITLE
add a tag to ECS Exec provisioned permission set

### DIFF
--- a/accesshandler/pkg/providers/aws/ecs-shell-sso/access.go
+++ b/accesshandler/pkg/providers/aws/ecs-shell-sso/access.go
@@ -477,10 +477,12 @@ func (p *Provider) createPermissionSetAndAssignment(ctx context.Context, subject
 		InstanceArn: aws.String(p.instanceARN.Get()),
 		Name:        aws.String(permissionSetName),
 		Description: aws.String("Granted Approvals ECS Flask Access"),
+		Tags:        []types.Tag{{Key: aws.String("managed-by-common-fate-granted"), Value: aws.String("true")}},
 	})
 	if err != nil {
 		return nil, err
 	}
+
 	// Assign ecs policy to permission set
 	_, err = p.ssoClient.PutInlinePolicyToPermissionSet(ctx, &ssoadmin.PutInlinePolicyToPermissionSetInput{
 		InlinePolicy:     aws.String(ecsPolicyDocument.String()),


### PR DESCRIPTION
allows ABAC to be used to further restrict the ECS Exec Access Provider's permissions