### PR TITLE
add permissions for groups feature

### DIFF
--- a/accesshandler/pkg/providers/aws/sso-v2/setup/2.md
+++ b/accesshandler/pkg/providers/aws/sso-v2/setup/2.md
@@ -39,13 +39,20 @@ Resources:
                   - sso:ListPermissionSets
                   - sso:ListTagsForResource
                   - sso:ListAccountAssignments
+                  - organizations:ListTagsForResource
                   - organizations:ListAccounts
+                  - organizations:ListRoots
+                  - organizations:ListChildrens
+                  - organizations:ListOrganizationalUnitsForParent
+                  - organizations:ListAccountsForParent
                   - organizations:DescribeOrganization
                   - iam:GetSAMLProvider
                   - iam:GetRole
                   - iam:ListAttachedRolePolicies
                   - iam:ListRolePolicies
                   - identitystore:ListUsers
+                  - resource-groups:SearchResources
+                  - tag:GetResources
                 Effect: Allow
                 Resource: "*"
               - Sid: AssignSSO

--- a/accesshandler/pkg/providers/aws/sso-v2/setup/2.md
+++ b/accesshandler/pkg/providers/aws/sso-v2/setup/2.md
@@ -43,18 +43,15 @@ Resources:
                   - organizations:DescribeOrganization
                   - organizations:ListAccounts
                   - organizations:ListAccountsForParent
-                  - organizations:ListChildrens
                   - organizations:ListOrganizationalUnitsForParent
                   - organizations:ListRoots
                   - organizations:ListTagsForResource
-                  - resource-groups:SearchResources
                   - sso:DescribeAccountAssignmentCreationStatus
                   - sso:DescribeAccountAssignmentDeletionStatus
                   - sso:DescribePermissionSet
                   - sso:ListAccountAssignments
                   - sso:ListPermissionSets
                   - sso:ListTagsForResource
-                  - tag:GetResources
                 Effect: Allow
                 Resource: "*"
               - Sid: AssignSSO

--- a/accesshandler/pkg/providers/aws/sso-v2/setup/2.md
+++ b/accesshandler/pkg/providers/aws/sso-v2/setup/2.md
@@ -32,7 +32,7 @@ Resources:
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
-               - Sid: ReadSSO
+              - Sid: ReadSSO
                 Action:
                   - iam:GetRole
                   - iam:GetSAMLProvider

--- a/accesshandler/pkg/providers/aws/sso-v2/setup/2.md
+++ b/accesshandler/pkg/providers/aws/sso-v2/setup/2.md
@@ -32,26 +32,28 @@ Resources:
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
-              - Sid: ReadSSO
+               - Sid: ReadSSO
                 Action:
-                  - sso:DescribeAccountAssignmentDeletionStatus
-                  - sso:DescribeAccountAssignmentCreationStatus
-                  - sso:ListPermissionSets
-                  - sso:ListTagsForResource
-                  - sso:ListAccountAssignments
-                  - organizations:ListTagsForResource
-                  - organizations:ListAccounts
-                  - organizations:ListRoots
-                  - organizations:ListChildrens
-                  - organizations:ListOrganizationalUnitsForParent
-                  - organizations:ListAccountsForParent
-                  - organizations:DescribeOrganization
-                  - iam:GetSAMLProvider
                   - iam:GetRole
+                  - iam:GetSAMLProvider
                   - iam:ListAttachedRolePolicies
                   - iam:ListRolePolicies
                   - identitystore:ListUsers
+                  - organizations:DescribeAccount
+                  - organizations:DescribeOrganization
+                  - organizations:ListAccounts
+                  - organizations:ListAccountsForParent
+                  - organizations:ListChildrens
+                  - organizations:ListOrganizationalUnitsForParent
+                  - organizations:ListRoots
+                  - organizations:ListTagsForResource
                   - resource-groups:SearchResources
+                  - sso:DescribeAccountAssignmentCreationStatus
+                  - sso:DescribeAccountAssignmentDeletionStatus
+                  - sso:DescribePermissionSet
+                  - sso:ListAccountAssignments
+                  - sso:ListPermissionSets
+                  - sso:ListTagsForResource
                   - tag:GetResources
                 Effect: Allow
                 Resource: "*"
@@ -60,8 +62,6 @@ Resources:
                   - iam:UpdateSAMLProvider
                   - sso:CreateAccountAssignment
                   - sso:DeleteAccountAssignment
-                  - sso:DescribePermissionSet
-                  - organizations:DescribeAccount
                 Effect: Allow
                 Resource: "*"
 Outputs:


### PR DESCRIPTION
Additional permissions required for the groups feature.
Allows rules to be created for organizational units