### PR TITLE
Enable KMS key rotation [APP-174]

### DIFF
--- a/deploy/infra/lib/constructs/app-backend.ts
+++ b/deploy/infra/lib/constructs/app-backend.ts
@@ -58,6 +58,7 @@ export class AppBackend extends Construct {
     this._KMSkey = new kms.Key(this, "PaginationKMSKey", {
       removalPolicy: cdk.RemovalPolicy.DESTROY,
       pendingWindow: cdk.Duration.days(7),
+      enableKeyRotation: true,
       description:
         "used for encrypting and decrypting pagination tokens for granted approvals",
     });


### PR DESCRIPTION
Enable KMS key automatic rotation. 
This is required by many security standards and it is a good practice.