### PR TITLE
Resolve performance issue with SSOv2 list arg options method [APP-178]

### DIFF
--- a/accesshandler/pkg/providers/aws/sso-v2/options.go
+++ b/accesshandler/pkg/providers/aws/sso-v2/options.go
@@ -145,7 +145,8 @@ func (p *Provider) listChildOusForParent(ctx context.Context, parentID string) (
 	var nextToken *string
 	for hasMore {
 		ou, err := p.orgClient.ListOrganizationalUnitsForParent(ctx, &organizations.ListOrganizationalUnitsForParentInput{
-			ParentId: aws.String(parentID),
+			ParentId:  aws.String(parentID),
+			NextToken: nextToken,
 		})
 		if err != nil {
 			return nil, err

--- a/accesshandler/pkg/providertest/organization-graph_test.go
+++ b/accesshandler/pkg/providertest/organization-graph_test.go
@@ -1,0 +1,38 @@
+package providertest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/common-fate/granted-approvals/accesshandler/pkg/config"
+	"github.com/common-fate/granted-approvals/accesshandler/pkg/providers"
+	"github.com/common-fate/granted-approvals/pkg/deploy"
+	"github.com/joho/godotenv"
+)
+
+func BenchmarkOrganizationGraph(b *testing.B) {
+	ctx := context.Background()
+	_ = godotenv.Load("../../../.env")
+	dc, err := deploy.GetDeploymentConfig()
+	if err != nil {
+		b.Fatal(err)
+	}
+	ps, err := dc.ReadProviders(ctx)
+	if err != nil {
+		b.Fatal(err)
+	}
+	err = config.ConfigureProviders(ctx, ps)
+	if err != nil {
+		b.Fatal(err)
+	}
+	sso := config.Providers["aws-sso-v2"]
+	op := sso.Provider.(providers.ArgOptioner)
+	for i := 0; i < b.N; i++ {
+		options, err := op.Options(ctx, "accountId")
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = options
+	}
+
+}

--- a/accesshandler/pkg/server/routes.go
+++ b/accesshandler/pkg/server/routes.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/common-fate/apikit/logger"
 	"github.com/common-fate/apikit/openapi"
@@ -21,7 +20,6 @@ func (s *Server) Routes() http.Handler {
 	r.Use(chiMiddleware.RequestID)
 	r.Use(chiMiddleware.RealIP)
 	r.Use(chiMiddleware.Recoverer)
-	r.Use(chiMiddleware.Timeout(30 * time.Second))
 	r.Use(logger.Middleware(s.rawLog.Desugar()))
 	r.Use(openapi.Validator(s.swagger))
 

--- a/cmd/gdeploy/commands/cache/cache.go
+++ b/cmd/gdeploy/commands/cache/cache.go
@@ -1,0 +1,16 @@
+package cache
+
+import (
+	"github.com/common-fate/granted-approvals/cmd/gdeploy/commands/identity/sync"
+	"github.com/urfave/cli/v2"
+)
+
+var Command = cli.Command{
+	Name:        "cache",
+	Description: "Utilities for managing the provider argument options cache",
+	Usage:       "Utilities for managing the provider argument options cache",
+	Action:      cli.ShowSubcommandHelp,
+	Subcommands: []*cli.Command{
+		&sync.SyncCommand,
+	},
+}

--- a/cmd/gdeploy/commands/cache/sync/sync.go
+++ b/cmd/gdeploy/commands/cache/sync/sync.go
@@ -59,7 +59,7 @@ var SyncCommand = cli.Command{
 		}
 		clio.Debugf("cache sync lamda invoke response: %s", string(b))
 		if res.FunctionError != nil {
-			return fmt.Errorf("user and group sync failed with lambda execution error: %s", *res.FunctionError)
+			return fmt.Errorf("cache sync failed with lambda execution error: %s", *res.FunctionError)
 		} else if res.StatusCode == 200 {
 
 			clio.Successf("Successfully synced the cache")

--- a/cmd/gdeploy/commands/cache/sync/sync.go
+++ b/cmd/gdeploy/commands/cache/sync/sync.go
@@ -1,0 +1,70 @@
+package sync
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"github.com/briandowns/spinner"
+	"github.com/common-fate/clio"
+	"github.com/common-fate/clio/clierr"
+	"github.com/common-fate/granted-approvals/pkg/cfaws"
+	"github.com/common-fate/granted-approvals/pkg/deploy"
+	"github.com/urfave/cli/v2"
+)
+
+var SyncCommand = cli.Command{
+	Name: "sync",
+	Action: func(c *cli.Context) error {
+		ctx := c.Context
+
+		dc, err := deploy.ConfigFromContext(ctx)
+		if err != nil {
+			return err
+		}
+		o, err := dc.LoadOutput(ctx)
+		if err != nil {
+			return err
+		}
+
+		cfg, err := cfaws.ConfigFromContextOrDefault(ctx)
+		if err != nil {
+			return err
+		}
+
+		if o.CacheSyncFunctionName == "" {
+			return clierr.New("The sync function name is not yet available. You may need to update your deployment to use this feature.")
+		}
+		si := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
+		si.Suffix = " invoking cache sync lambda function"
+		si.Writer = os.Stderr
+		si.Start()
+
+		lambdaClient := lambda.NewFromConfig(cfg)
+		res, err := lambdaClient.Invoke(ctx, &lambda.InvokeInput{
+			FunctionName:   &o.IdpSyncFunctionName,
+			InvocationType: types.InvocationTypeRequestResponse,
+			Payload:        []byte("{}"),
+		})
+		si.Stop()
+		if err != nil {
+			return err
+		}
+		b, err := json.Marshal(res)
+		if err != nil {
+			return err
+		}
+		clio.Debugf("cache sync lamda invoke response: %s", string(b))
+		if res.FunctionError != nil {
+			return fmt.Errorf("user and group sync failed with lambda execution error: %s", *res.FunctionError)
+		} else if res.StatusCode == 200 {
+
+			clio.Successf("Successfully synced the cache")
+		} else {
+			return fmt.Errorf("cache sync failed with lambda invoke status code: %d", res.StatusCode)
+		}
+		return nil
+	}}

--- a/cmd/gdeploy/main.go
+++ b/cmd/gdeploy/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/common-fate/clio/clierr"
 	"github.com/common-fate/granted-approvals/cmd/gdeploy/commands"
 	"github.com/common-fate/granted-approvals/cmd/gdeploy/commands/backup"
+	"github.com/common-fate/granted-approvals/cmd/gdeploy/commands/cache"
 	"github.com/common-fate/granted-approvals/cmd/gdeploy/commands/dashboard"
 	"github.com/common-fate/granted-approvals/cmd/gdeploy/commands/identity"
 	"github.com/common-fate/granted-approvals/cmd/gdeploy/commands/logs"
@@ -57,6 +58,7 @@ func main() {
 			mw.WithBeforeFuncs(&provider.Command, mw.RequireDeploymentConfig(), mw.VerifyGDeployCompatibility(), mw.RequireAWSCredentials()),
 			mw.WithBeforeFuncs(&notifications.Command, mw.RequireDeploymentConfig(), mw.VerifyGDeployCompatibility(), mw.RequireAWSCredentials()),
 			mw.WithBeforeFuncs(&dashboard.Command, mw.RequireDeploymentConfig(), mw.VerifyGDeployCompatibility(), mw.RequireAWSCredentials()),
+			mw.WithBeforeFuncs(&cache.Command, mw.RequireDeploymentConfig(), mw.RequireAWSCredentials()),
 			mw.WithBeforeFuncs(&commands.InitCommand, mw.RequireAWSCredentials()),
 			mw.WithBeforeFuncs(&release.Command, mw.RequireDeploymentConfig()),
 		},

--- a/deploy/infra/lib/constructs/access-handler.ts
+++ b/deploy/infra/lib/constructs/access-handler.ts
@@ -92,7 +92,7 @@ export class AccessHandler extends Construct {
 
     this._lambda = new lambda.Function(this, "RestAPIHandlerFunction", {
       code,
-      timeout: Duration.seconds(120),
+      timeout: Duration.seconds(60),
       environment: {
         GRANTED_RUNTIME: "lambda",
         STATE_MACHINE_ARN: this._granter.getStateMachineARN(),
@@ -102,7 +102,6 @@ export class AccessHandler extends Construct {
         REMOTE_CONFIG_URL: props.remoteConfigUrl,
         REMOTE_CONFIG_HEADERS: props.remoteConfigHeaders,
       },
-      memorySize: 1024,
       runtime: lambda.Runtime.GO_1_X,
       handler: "access-handler",
       role: this._executionRole,

--- a/deploy/infra/lib/constructs/access-handler.ts
+++ b/deploy/infra/lib/constructs/access-handler.ts
@@ -92,7 +92,7 @@ export class AccessHandler extends Construct {
 
     this._lambda = new lambda.Function(this, "RestAPIHandlerFunction", {
       code,
-      timeout: Duration.seconds(60),
+      timeout: Duration.seconds(120),
       environment: {
         GRANTED_RUNTIME: "lambda",
         STATE_MACHINE_ARN: this._granter.getStateMachineARN(),
@@ -102,6 +102,7 @@ export class AccessHandler extends Construct {
         REMOTE_CONFIG_URL: props.remoteConfigUrl,
         REMOTE_CONFIG_HEADERS: props.remoteConfigHeaders,
       },
+      memorySize: 1024,
       runtime: lambda.Runtime.GO_1_X,
       handler: "access-handler",
       role: this._executionRole,

--- a/deploy/infra/lib/constructs/cache-sync.ts
+++ b/deploy/infra/lib/constructs/cache-sync.ts
@@ -25,13 +25,12 @@ export class CacheSync extends Construct {
 
     this._lambda = new lambda.Function(this, "HandlerFunction", {
       code,
-      timeout: Duration.seconds(120),
+      timeout: Duration.seconds(60),
       environment: {
         ACCESS_HANDLER_URL: props.accessHandler.getApiUrl(),
         APPROVALS_TABLE_NAME: props.dynamoTable.tableName,
       },
       runtime: lambda.Runtime.GO_1_X,
-      memorySize: 256,
       handler: "cache-sync",
     });
 

--- a/deploy/infra/lib/constructs/cache-sync.ts
+++ b/deploy/infra/lib/constructs/cache-sync.ts
@@ -25,12 +25,13 @@ export class CacheSync extends Construct {
 
     this._lambda = new lambda.Function(this, "HandlerFunction", {
       code,
-      timeout: Duration.seconds(20),
+      timeout: Duration.seconds(120),
       environment: {
         ACCESS_HANDLER_URL: props.accessHandler.getApiUrl(),
         APPROVALS_TABLE_NAME: props.dynamoTable.tableName,
       },
       runtime: lambda.Runtime.GO_1_X,
+      memorySize: 256,
       handler: "cache-sync",
     });
 

--- a/deploy/infra/lib/granted-approvals-stack-prod.ts
+++ b/deploy/infra/lib/granted-approvals-stack-prod.ts
@@ -243,6 +243,7 @@ export class CustomerGrantedStack extends cdk.Stack {
       CacheSyncLogGroupName: appBackend.getCacheSync().getLogGroupName(),
       IDPSyncExecutionRoleARN: appBackend.getIdpSync().getExecutionRoleArn(),
       RestAPIExecutionRoleARN: appBackend.getExecutionRoleArn(),
+      CacheSyncFunctionName: appBackend.getCacheSync().getFunctionName(),
     });
   }
 }

--- a/deploy/infra/lib/granted-approvals-stack.ts
+++ b/deploy/infra/lib/granted-approvals-stack.ts
@@ -131,6 +131,7 @@ export class DevGrantedStack extends cdk.Stack {
       CacheSyncLogGroupName: approvals.getCacheSync().getLogGroupName(),
       IDPSyncExecutionRoleARN: approvals.getIdpSync().getExecutionRoleArn(),
       RestAPIExecutionRoleARN: approvals.getExecutionRoleArn(),
+      CacheSyncFunctionName: approvals.getCacheSync().getFunctionName(),
     });
   }
 }

--- a/deploy/infra/lib/helpers/outputs.ts
+++ b/deploy/infra/lib/helpers/outputs.ts
@@ -30,6 +30,7 @@ export type StackOutputs = {
   CacheSyncLogGroupName: string;
   RestAPIExecutionRoleARN: string;
   IDPSyncExecutionRoleARN: string;
+  CacheSyncFunctionName: string;
 };
 /**
  * generateOutputs creates a Cloudformation Output for each key-value pair in the type StackOutputs

--- a/deploy/infra/test/stack-outputs.ts
+++ b/deploy/infra/test/stack-outputs.ts
@@ -33,6 +33,7 @@ const testOutputs: StackOutputs = {
   CacheSyncLogGroupName: "abcdefg",
   RestAPIExecutionRoleARN: "abcdefg",
   IDPSyncExecutionRoleARN: "abcdefg",
+  CacheSyncFunctionName: "abcdefg",
 };
 
 // Write the json object to ./testOutputs.json so that it can be parsed by a go test in pkg/deploy.output_test.go

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v0.5.3
 	github.com/aws/aws-sdk-go v1.44.71
-	github.com/aws/aws-sdk-go-v2 v1.16.16
+	github.com/aws/aws-sdk-go-v2 v1.17.1
 	github.com/aws/aws-sdk-go-v2/config v1.15.16
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.22
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.22.2
@@ -13,7 +13,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/eks v1.21.8
 	github.com/aws/aws-sdk-go-v2/service/iam v1.18.13
 	github.com/aws/aws-sdk-go-v2/service/identitystore v1.15.5
-	github.com/aws/aws-sdk-go-v2/service/organizations v1.16.6
+	github.com/aws/aws-sdk-go-v2/service/organizations v1.16.15
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.21.5
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.13.10
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.28.0
@@ -140,15 +140,15 @@ require (
 require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.12.11 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.10 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.23 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.17 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.25 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.19 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.7.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.11.14 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.11
-	github.com/aws/smithy-go v1.13.3
+	github.com/aws/smithy-go v1.13.4
 	github.com/benbjohnson/clock v1.3.0
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,8 @@ github.com/aws/aws-sdk-go-v2 v1.16.12/go.mod h1:C+Ym0ag2LIghJbXhfXZ0YEEp49rBWowx
 github.com/aws/aws-sdk-go-v2 v1.16.15/go.mod h1:SwiyXi/1zTUZ6KIAmLK5V5ll8SiURNUYOqTerZPaF9k=
 github.com/aws/aws-sdk-go-v2 v1.16.16 h1:M1fj4FE2lB4NzRb9Y0xdWsn2P0+2UHVxwKyOa4YJNjk=
 github.com/aws/aws-sdk-go-v2 v1.16.16/go.mod h1:SwiyXi/1zTUZ6KIAmLK5V5ll8SiURNUYOqTerZPaF9k=
+github.com/aws/aws-sdk-go-v2 v1.17.1 h1:02c72fDJr87N8RAC2s3Qu0YuvMRZKNZJ9F+lAehCazk=
+github.com/aws/aws-sdk-go-v2 v1.17.1/go.mod h1:JLnGeGONAyi2lWXI1p0PCIOIy333JMVK1U7Hf0aRFLw=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.3 h1:S/ZBwevQkr7gv5YxONYpGQxlMFFYSRfz3RMcjsC9Qhk=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.3/go.mod h1:gNsR5CaXKmQSSzrmGxmwmct/r+ZBfbxorAuXYsj/M5Y=
 github.com/aws/aws-sdk-go-v2/config v1.1.6/go.mod h1:Kx90DDOgkMpRfSkzGbF13AVXHHfBNct1liO+95KxXsU=
@@ -152,6 +154,8 @@ github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.19/go.mod h1:llxE6bwUZh
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.22/go.mod h1:/vNv5Al0bpiF8YdX2Ov6Xy05VTiXsql94yUqJMYaj0w=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.23 h1:s4g/wnzMf+qepSNgTvaQQHNxyMLKSawNhKCPNy++2xY=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.23/go.mod h1:2DFxAQ9pfIRy0imBCJv+vZ2X6RKxves6fbnEuSry6b4=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.25 h1:nBO/RFxeq/IS5G9Of+ZrgucRciie2qpLy++3UGZ+q2E=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.25/go.mod h1:Zb29PYkf42vVYQY6pvSyJCJcFHlPIiY+YKdPtwnvMkY=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.4/go.mod h1:8glyUqVIM4AmeenIsPo0oVh3+NUwnsQml2OFupfQW+0=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.5/go.mod h1:fV1AaS2gFc1tM0RCb015FJ0pvWVUfJZANzjwoO4YakM=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.6/go.mod h1:FwpAKI+FBPIELJIdmQzlLtRe8LQSOreMcM2wBsPMvvc=
@@ -163,6 +167,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.13/go.mod h1:lB12mkZqCSo
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.16/go.mod h1:62dsXI0BqTIGomDl8Hpm33dv0OntGaVblri3ZRParVQ=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.17 h1:/K482T5A3623WJgWT8w1yRAFK4RzGzEl7y39yhtn9eA=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.17/go.mod h1:pRwaTYCJemADaqCbUAxltMoHKata7hmB5PjEXeu0kfg=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.19 h1:oRHDrwCTVT8ZXi4sr9Ld+EXk7N/KGssOr2ygNeojEhw=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.19/go.mod h1:6Q0546uHDp421okhmmGfbxzq2hBqbXFNpi4k+Q1JnQA=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.17 h1:9afA9eNkHujiJHsV6OjbBdFon6R7XSFxi1H7jU6Q6u8=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.17/go.mod h1:2C5+mYysnLDg/irvoEVXcrnco/wPF6jWb/XA7V8bOqc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.2/go.mod h1:0jDVeWUFPbI3sOfsXXAsIdiawXcn7VBLx/IlFVTRP64=
@@ -216,6 +222,8 @@ github.com/aws/aws-sdk-go-v2/service/lambda v1.23.4 h1:d1Olp+josNRAlrrtacghtos74
 github.com/aws/aws-sdk-go-v2/service/lambda v1.23.4/go.mod h1:XiSHsT7z5ScD2AsTgfa1UEFQaAr53dHP1oWvaqSW6jQ=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.16.6 h1:9b+lMzIdhNdrZH9I+m8tJyAHM5/op76WGNA2IN9NBxk=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.16.6/go.mod h1:xsR4BhOKE6FrKzlCwNQYYtDYPmMsmqSneh3oW2+Gtns=
+github.com/aws/aws-sdk-go-v2/service/organizations v1.16.15 h1:DKPB04iAh04HwzriUgKlnRYfrpQzWkbjRdvnePO1glM=
+github.com/aws/aws-sdk-go-v2/service/organizations v1.16.15/go.mod h1:ysLUNmzoQk89rK4yF0hjDBEX83YCuYSw6fK6KXqXpJ0=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.21.5 h1:8DftBq96N8OjTTDNpy90SEAIN3Y7bOh6s/W91i9GO1U=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.21.5/go.mod h1:bHyncRqcDob/Fc0ZSUa4J8fuBeiet86AutmXQKc+R+M=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.5.0/go.mod h1:uwA7gs93Qcss43astPUb1eq4RyceNmYWAQjZFDOAMLo=
@@ -241,6 +249,8 @@ github.com/aws/smithy-go v1.12.1/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J
 github.com/aws/smithy-go v1.13.0/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/aws/smithy-go v1.13.3 h1:l7LYxGuzK6/K+NzJ2mC+VvLUbae0sL3bXU//04MkmnA=
 github.com/aws/smithy-go v1.13.3/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
+github.com/aws/smithy-go v1.13.4 h1:/RN2z1txIJWeXeOkzX+Hk/4Uuvv7dWtCjbmVJcrskyk=
+github.com/aws/smithy-go v1.13.4/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/awslabs/aws-lambda-go-api-proxy v0.13.3 h1:kGtltTONdJa0Bmot9phYw3ucCg2SExj6mH00I1aga8Y=
 github.com/awslabs/aws-lambda-go-api-proxy v0.13.3/go.mod h1:S5mIpII0ID7L9o6bN8VNwO69UpWMg/j4IympsjtKghE=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=

--- a/pkg/deploy/output.go
+++ b/pkg/deploy/output.go
@@ -46,6 +46,7 @@ type Output struct {
 	CacheSyncLogGroupName         string `json:"CacheSyncLogGroupName"`
 	RestAPIExecutionRoleARN       string `json:"RestAPIExecutionRoleARN"`
 	IDPSyncExecutionRoleARN       string `json:"IDPSyncExecutionRoleARN"`
+	CacheSyncFunctionName         string `json:"CacheSyncFunctionName"`
 }
 
 func (c Output) FrontendURL() string {

--- a/pkg/deploy/output_test.go
+++ b/pkg/deploy/output_test.go
@@ -64,6 +64,7 @@ func TestOutputStructMatchesTSType(t *testing.T) {
 		CacheSyncLogGroupName:         "abcdefg",
 		RestAPIExecutionRoleARN:       "abcdefg",
 		IDPSyncExecutionRoleARN:       "abcdefg",
+		CacheSyncFunctionName:         "abcdefg",
 	}
 	b, err := json.Marshal(output)
 	if err != nil {
@@ -115,6 +116,7 @@ func TestOutput_Get(t *testing.T) {
 		Region                        string
 		PaginationKMSKeyARN           string
 		AccessHandlerExecutionRoleARN string
+		CacheSyncFunctionName         string
 	}
 	type args struct {
 		key string

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/common-fate/apikit/logger"
 	"github.com/common-fate/apikit/openapi"
@@ -18,7 +17,6 @@ func (c *Server) Handler() http.Handler {
 	r.Use(c.requestIDMiddleware)
 	r.Use(chiMiddleware.RealIP)
 	r.Use(chiMiddleware.Recoverer)
-	r.Use(chiMiddleware.Timeout(30 * time.Second))
 	r.Use(logger.Middleware(c.log.Desugar()))
 	r.Use(sentryMiddleware)
 	r.Use(cors.Handler(cors.Options{


### PR DESCRIPTION
This resolves an issue encountered by some users with large AWS organizations for example ~100 accounts.

In some cases when the ListOrganizationalUnitsForParent api call does not return results on the first request, the function would enter an infinite loop until terminated by an API timeout because the nextToken was not being included in the request.