### PR TITLE
analytics: don't identify provider IDs [APP-182]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -185,7 +185,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.23.4
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.3
 	github.com/briandowns/spinner v1.18.1
-	github.com/common-fate/analytics-go v0.0.0-20221103150131-462978118bbf
+	github.com/common-fate/analytics-go v0.1.0
 	github.com/common-fate/clio v1.0.0
 	github.com/common-fate/ddb v0.15.0
 	github.com/common-fate/testvault v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -323,6 +323,8 @@ github.com/common-fate/analytics-go v0.0.0-20221103140702-fc45d6ea26d3 h1:2H3p5k
 github.com/common-fate/analytics-go v0.0.0-20221103140702-fc45d6ea26d3/go.mod h1:RmsNL2tYC00c7/pOzgHQYrTMRlY6tp201VFZbAqFCTE=
 github.com/common-fate/analytics-go v0.0.0-20221103150131-462978118bbf h1:cg6SnOf/qjpM6sW9cwpFJ35RuiIgXumUoRAYsyhqKeU=
 github.com/common-fate/analytics-go v0.0.0-20221103150131-462978118bbf/go.mod h1:RmsNL2tYC00c7/pOzgHQYrTMRlY6tp201VFZbAqFCTE=
+github.com/common-fate/analytics-go v0.1.0 h1:NbbT8l8v5iSGFx5dGte7nzKXWYyuQuyc9gti3E4FbIw=
+github.com/common-fate/analytics-go v0.1.0/go.mod h1:RmsNL2tYC00c7/pOzgHQYrTMRlY6tp201VFZbAqFCTE=
 github.com/common-fate/apikit v0.2.1-0.20220526131641-1d860b34f6ed h1:75bNrGY5m/CLnxt5IajGf424YiM2WO+5GRgTPvFcLVo=
 github.com/common-fate/apikit v0.2.1-0.20220526131641-1d860b34f6ed/go.mod h1:5WXBU3NBnQ6ZuqQyazwL5Ou6yT7UpC8c3yK8F9mGh9k=
 github.com/common-fate/clio v1.0.0 h1:jUyXGfN4/oqDn6DvrOpTUVBLdjczxFonzJC2ee0Ashc=

--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -331,7 +331,6 @@ func (a *API) RevokeRequest(w http.ResponseWriter, r *http.Request, requestID st
 	analytics.FromContext(ctx).Track(&analytics.RequestRevoked{
 		RequestedBy: req.RequestedBy,
 		RevokedBy:   uid,
-		Provider:    req.Grant.Provider,
 		RuleID:      req.Rule,
 		Timing:      req.RequestedTiming.ToAnalytics(),
 		HasReason:   req.HasReason(),

--- a/pkg/service/accesssvc/create.go
+++ b/pkg/service/accesssvc/create.go
@@ -195,7 +195,7 @@ func (s *Service) CreateRequest(ctx context.Context, user *identity.User, in typ
 	// analytics event
 	analytics.FromContext(ctx).Track(&analytics.RequestCreated{
 		RequestedBy:      req.RequestedBy,
-		Provider:         rule.Target.ProviderID,
+		Provider:         rule.Target.ProviderType,
 		RuleID:           req.Rule,
 		Timing:           req.RequestedTiming.ToAnalytics(),
 		HasReason:        req.HasReason(),


### PR DESCRIPTION
they aren't necessarily sensitive and are auto-generated/incremented, but this should be the provider type. The 'request.created' event used the ID.

Also uses a tagged version of analytics-go rather than a git SHA.