### PR TITLE
Update arg options api calls for create rule form

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -167,31 +167,35 @@ func New(ctx context.Context, opts Opts) (*API, error) {
 			Granter:     granter,
 			EventPutter: opts.EventSender,
 			Cache: &cachesvc.Service{
-				DB:                  db,
-				AccessHandlerClient: opts.AccessHandlerClient,
+				ProviderConfigReader: opts.DeploymentConfig,
+				DB:                   db,
+				AccessHandlerClient:  opts.AccessHandlerClient,
 			},
 			Rules: &rulesvc.Service{
 				Clock:    clk,
 				DB:       db,
 				AHClient: opts.AccessHandlerClient,
 				Cache: &cachesvc.Service{
-					DB:                  db,
-					AccessHandlerClient: opts.AccessHandlerClient,
+					ProviderConfigReader: opts.DeploymentConfig,
+					DB:                   db,
+					AccessHandlerClient:  opts.AccessHandlerClient,
 				},
 			},
 			AHClient: opts.AccessHandlerClient,
 		},
 		Cache: &cachesvc.Service{
-			DB:                  db,
-			AccessHandlerClient: opts.AccessHandlerClient,
+			ProviderConfigReader: opts.DeploymentConfig,
+			DB:                   db,
+			AccessHandlerClient:  opts.AccessHandlerClient,
 		},
 		Rules: &rulesvc.Service{
 			Clock:    clk,
 			DB:       db,
 			AHClient: opts.AccessHandlerClient,
 			Cache: &cachesvc.Service{
-				DB:                  db,
-				AccessHandlerClient: opts.AccessHandlerClient,
+				ProviderConfigReader: opts.DeploymentConfig,
+				DB:                   db,
+				AccessHandlerClient:  opts.AccessHandlerClient,
 			},
 		},
 		ProviderSetup: &psetupsvc.Service{

--- a/pkg/api/provider.go
+++ b/pkg/api/provider.go
@@ -98,6 +98,7 @@ func (a *API) GetProviderArgs(w http.ResponseWriter, r *http.Request, providerId
 // (GET /api/v1/admin/providers/{providerId}/args/{argId}/options)
 func (a *API) ListProviderArgOptions(w http.ResponseWriter, r *http.Request, providerId string, argId string, params types.ListProviderArgOptionsParams) {
 	ctx := r.Context()
+
 	res := ahTypes.ArgOptionsResponse{
 		Options: []ahTypes.Option{},
 		Groups:  &ahTypes.Groups{AdditionalProperties: make(map[string][]ahTypes.GroupOption)},

--- a/pkg/service/cachesvc/service.go
+++ b/pkg/service/cachesvc/service.go
@@ -1,12 +1,20 @@
 package cachesvc
 
 import (
+	"context"
+
 	"github.com/common-fate/ddb"
 	ahtypes "github.com/common-fate/granted-approvals/accesshandler/pkg/types"
+	"github.com/common-fate/granted-approvals/pkg/deploy"
 )
 
 // Service holds business logic relating to Access Requests.
 type Service struct {
-	DB                  ddb.Storage
-	AccessHandlerClient ahtypes.ClientWithResponsesInterface
+	DB                   ddb.Storage
+	AccessHandlerClient  ahtypes.ClientWithResponsesInterface
+	ProviderConfigReader ProviderConfigReader
+}
+
+type ProviderConfigReader interface {
+	ReadProviders(ctx context.Context) (deploy.ProviderMap, error)
 }

--- a/web/src/components/forms/access-rule/components/ProviderArgumentField.tsx
+++ b/web/src/components/forms/access-rule/components/ProviderArgumentField.tsx
@@ -192,7 +192,23 @@ const ProviderFormElementMultiSelect: React.FC<ProviderArgumentFieldProps> = ({
     argOptions?.options.filter((option) => {
       return effectiveAccountIds.includes(option.value);
     }) || [];
-  const required = effectiveOptions.length === 0;
+
+  // Will be true if no groups have been selected
+  const argumentSelectionRequired =
+    Object.entries(argumentGroups || {}).find(([k, v]) => v.length > 0) ===
+    undefined;
+
+  // true if no argument values have been selected
+  const groupSelectionRequired =
+    multiSelects === undefined || multiSelects.length === 0;
+  console.log({
+    id: argument.id,
+    argumentSelectionRequired,
+    groupSelectionRequired,
+    argumentGroups,
+    multiSelects,
+    watch: watch(),
+  });
 
   return (
     <VStack
@@ -222,7 +238,7 @@ const ProviderFormElementMultiSelect: React.FC<ProviderArgumentFieldProps> = ({
         </FormLabel>
         <HStack w="90%">
           <MultiSelect
-            rules={{ required: required, minLength: 1 }}
+            rules={{ required: argumentSelectionRequired, minLength: 1 }}
             fieldName={`target.multiSelects.${argument.id}`}
             options={argOptions?.options || []}
             shouldAddSelectAllOption={true}
@@ -283,7 +299,10 @@ const ProviderFormElementMultiSelect: React.FC<ProviderArgumentFieldProps> = ({
                     </FormLabel>
                     <HStack w="90%">
                       <MultiSelect
-                        rules={{ required: required, minLength: 1 }}
+                        rules={{
+                          required: groupSelectionRequired,
+                          minLength: 1,
+                        }}
                         fieldName={`target.argumentGroups.${argument.id}.${group.id}`}
                         options={argOptions.groups[group.id] || []}
                         shouldAddSelectAllOption={true}

--- a/web/src/components/forms/access-rule/components/Select.tsx
+++ b/web/src/components/forms/access-rule/components/Select.tsx
@@ -181,8 +181,8 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
               onChange(val.map((c: any) => c.value));
             }}
             onBlur={() => {
-              void trigger(fieldName);
               rest.onBlurSecondaryAction && rest.onBlurSecondaryAction();
+              onBlur();
             }}
             data-testid={rest.testId}
             {...rest}

--- a/web/src/components/forms/access-rule/steps/FormStep.tsx
+++ b/web/src/components/forms/access-rule/steps/FormStep.tsx
@@ -18,6 +18,7 @@ interface FormStepProps {
   // the fields that this form component contains, used for validating the step before enabling next
   fields: string[];
   hideNext?: boolean;
+  isFieldLoading?: boolean;
   preview?: React.ReactElement;
   children?: React.ReactElement;
 }
@@ -28,6 +29,7 @@ export const FormStep: React.FC<FormStepProps> = ({
   subHeading,
   fields,
   preview,
+  isFieldLoading,
 }) => {
   const { trigger, getFieldState } = useFormContext();
   const { active } = useFormStep();
@@ -65,7 +67,7 @@ export const FormStep: React.FC<FormStepProps> = ({
             </VStack>
             <BottomActionButtons
               validate={runValidation}
-              hasErrors={hasFieldErrors}
+              hasErrors={hasFieldErrors || !!isFieldLoading}
             />
           </VStack>
         </Collapse>

--- a/web/src/components/forms/access-rule/steps/Provider.tsx
+++ b/web/src/components/forms/access-rule/steps/Provider.tsx
@@ -94,7 +94,10 @@ export const RefreshButton: React.FC<RefreshButtonProps> = ({
   ...props
 }) => {
   const [loading, setLoading] = useState(false);
-  const { mutate, isValidating } = useListProviderArgOptions(providerId, argId);
+  const { data, mutate, isValidating } = useListProviderArgOptions(
+    providerId,
+    argId
+  );
 
   const onClick = async () => {
     setLoading(true);
@@ -111,7 +114,7 @@ export const RefreshButton: React.FC<RefreshButtonProps> = ({
       <IconButton
         {...props}
         onClick={onClick}
-        isLoading={isValidating || loading}
+        isLoading={(!data && isValidating) || loading}
         icon={<RefreshIcon boxSize="24px" />}
         aria-label="Refresh"
         variant={"ghost"}

--- a/web/src/components/forms/access-rule/steps/Provider.tsx
+++ b/web/src/components/forms/access-rule/steps/Provider.tsx
@@ -94,14 +94,15 @@ export const RefreshButton: React.FC<RefreshButtonProps> = ({
   ...props
 }) => {
   const [loading, setLoading] = useState(false);
-  const { mutate } = useListProviderArgOptions(providerId, argId);
+  const { mutate, isValidating } = useListProviderArgOptions(providerId, argId);
 
   const onClick = async () => {
     setLoading(true);
-    const res = await listProviderArgOptions(providerId, argId, {
-      refresh: true,
-    });
-    await mutate(res);
+    await mutate(
+      listProviderArgOptions(providerId, argId, {
+        refresh: true,
+      })
+    );
     setLoading(false);
   };
 
@@ -110,7 +111,7 @@ export const RefreshButton: React.FC<RefreshButtonProps> = ({
       <IconButton
         {...props}
         onClick={onClick}
-        isLoading={loading}
+        isLoading={isValidating || loading}
         icon={<RefreshIcon boxSize="24px" />}
         aria-label="Refresh"
         variant={"ghost"}

--- a/web/src/components/forms/access-rule/steps/Provider.tsx
+++ b/web/src/components/forms/access-rule/steps/Provider.tsx
@@ -30,8 +30,12 @@ export const ProviderStep: React.FC = () => {
   const methods = useFormContext<AccessRuleFormData>();
   const target = methods.watch("target");
 
-  const { data: provider } = useGetProvider(target?.providerId);
-  const { data: providerArgs } = useGetProviderArgs(target?.providerId ?? "");
+  const { data: provider, isValidating: ivp } = useGetProvider(
+    target?.providerId
+  );
+  const { data: providerArgs, isValidating: ivpa } = useGetProviderArgs(
+    target?.providerId ?? ""
+  );
 
   const Preview = () => {
     if (!target || !provider || !(target?.inputs || target?.multiSelects)) {
@@ -39,6 +43,7 @@ export const ProviderStep: React.FC = () => {
     }
     return <ProviderPreview provider={provider} />;
   };
+  const isFieldLoading = (!provider && ivp) || (!providerArgs && ivpa);
 
   return (
     <FormStep
@@ -46,6 +51,7 @@ export const ProviderStep: React.FC = () => {
       subHeading="The permissions that the rule gives access to"
       fields={["target", "target.providerId"]}
       preview={<Preview />}
+      isFieldLoading={isFieldLoading}
     >
       <>
         <FormControl isInvalid={!!methods.formState.errors.target?.providerId}>

--- a/web/src/components/forms/access-rule/steps/Provider.tsx
+++ b/web/src/components/forms/access-rule/steps/Provider.tsx
@@ -33,25 +33,6 @@ export const ProviderStep: React.FC = () => {
   const { data: provider } = useGetProvider(target?.providerId);
   const { data: providerArgs } = useGetProviderArgs(target?.providerId ?? "");
 
-  // trigger a refresh of all provider arg options in the background when the provider is selected.
-  // this helps to keep the cached options fresh.
-  useEffect(() => {
-    if (providerArgs != null) {
-      const args = Object.values(providerArgs);
-
-      // TODO: Currenly, we have only multi-select and input form element defined.
-      // If in future, we have other form element that doesn't have options then we need to change
-      // the if condition here.
-      args.forEach((arg) => {
-        if (arg.ruleFormElement != ArgumentRuleFormElement.INPUT) {
-          void listProviderArgOptions(target.providerId, arg.id, {
-            refresh: true,
-          });
-        }
-      });
-    }
-  }, [providerArgs, target?.providerId]);
-
   const Preview = () => {
     if (!target || !provider || !(target?.inputs || target?.multiSelects)) {
       return null;

--- a/web/src/components/tables/SelectRuleTable.tsx
+++ b/web/src/components/tables/SelectRuleTable.tsx
@@ -25,28 +25,13 @@ import { durationString } from "../../utils/durationString";
 import { ProviderIcon } from "../icons/providerIcon";
 import { TableRenderer } from "./TableRenderer";
 
-type MyLocationGenerics = MakeGenerics<{
-  Search: {
-    status?: Lowercase<AccessRuleStatus>;
-  };
-}>;
-
 // Note: I made this type because the table column types don't seem to work with complex data
 // We need access to the selectabeloptions when redirecting to the request page
 interface ExtendedAR extends AccessRule {
   selectableWithOptionValues?: KeyValue[];
 }
 export const SelectRuleTable = ({ rules }: { rules: LookupAccessRule[] }) => {
-  const search = useSearch<MyLocationGenerics>();
-  const navigate = useNavigate<MyLocationGenerics>();
-
-  const status = useMemo(
-    () =>
-      search.status !== undefined
-        ? (search.status.toUpperCase() as AccessRuleStatus)
-        : AccessRuleStatus.ACTIVE,
-    [search]
-  );
+  const navigate = useNavigate();
 
   const cols = useMemo<Column<ExtendedAR>[]>(
     () => [
@@ -186,12 +171,12 @@ export const SelectRuleTable = ({ rules }: { rules: LookupAccessRule[] }) => {
           onClick: (e) => {
             const { selectableWithOptionValues, ...accessRule } = rule.original;
             e.preventDefault();
-            navigate({
-              to: makeLookupAccessRuleRequestLink({
+            navigate(
+              makeLookupAccessRuleRequestLink({
                 accessRule,
                 selectableWithOptionValues,
-              }),
-            });
+              })
+            );
           },
         }),
       })}

--- a/web/src/pages/access/index.tsx
+++ b/web/src/pages/access/index.tsx
@@ -2,15 +2,42 @@ import { InfoIcon } from "@chakra-ui/icons";
 import { Box, Center, Flex, Spinner, Text, useToast } from "@chakra-ui/react";
 import axios, { Axios, AxiosError } from "axios";
 import { useEffect, useState } from "react";
-import { Link, MakeGenerics, useNavigate, useSearch } from "react-location";
+import {
+  BuildNextOptions,
+  Link,
+  MakeGenerics,
+  useNavigate,
+  useSearch,
+} from "react-location";
 import { CFCodeMultiline } from "../../components/CodeInstruction";
 import { UserLayout } from "../../components/Layout";
 import { OnboardingCard } from "../../components/OnboardingCard";
 import { SelectRuleTable } from "../../components/tables/SelectRuleTable";
 import { useAccessRuleLookup } from "../../utils/backend-client/default/default";
-import { LookupAccessRule } from "../../utils/backend-client/types";
+import {
+  CreateRequestWith,
+  LookupAccessRule,
+} from "../../utils/backend-client/types";
 import { AccessRuleLookupParams } from "../../utils/backend-client/types/accessRuleLookupParams";
-
+import { RequestFormQueryParameters } from "./request/[id]";
+// const a: RequestFormQueryParameters = {
+//   Search: {
+//     reason: getValues("reason"),
+//     with: (getValues("with") || [])
+//       .filter((fw) => !fw.hidden)
+//       .map((fw) => fw.data),
+//   },
+// };
+// const timing: RequestTiming = {
+//   durationSeconds: getValues("timing.durationSeconds"),
+// };
+// if (getValues("when") === "scheduled") {
+//   timing.startTime = new Date(getValues("startDateTime")).toISOString();
+// }
+// a.Search.timing = timing;
+// const u = new URL(window.location.href);
+// u.search = location.stringifySearch(a.Search);
+// setUrlClipboardValue(u.toString());
 /**
  * makeLookupAccessRuleRequestLink adds request parameters to the URLso that forms can be prepopulated when there are multiple options for a user
  * @param lookupResult
@@ -18,13 +45,20 @@ import { AccessRuleLookupParams } from "../../utils/backend-client/types/accessR
  */
 export const makeLookupAccessRuleRequestLink = (
   lookupResult: LookupAccessRule
-) => {
-  const query = lookupResult.selectableWithOptionValues
-    ?.map((o) => `${o.key}=${o.value}`)
-    .join("&");
-  return `/access/request/${lookupResult.accessRule.id}${
-    query ? `?${query}` : ""
-  }`;
+): BuildNextOptions<RequestFormQueryParameters> => {
+  const w: CreateRequestWith = {};
+  lookupResult.selectableWithOptionValues?.forEach(
+    (o) => (w[o.key] = [o.value])
+  );
+  const a: RequestFormQueryParameters = {
+    Search: {
+      with: [w],
+    },
+  };
+  return {
+    to: `/access/request/${lookupResult.accessRule.id}`,
+    search: a.Search,
+  };
 };
 const Access = () => {
   type MyLocationGenerics = MakeGenerics<{
@@ -40,9 +74,7 @@ const Access = () => {
   const toast = useToast();
   useEffect(() => {
     if (data?.length == 1) {
-      navigate({
-        to: makeLookupAccessRuleRequestLink(data[0]),
-      });
+      navigate(makeLookupAccessRuleRequestLink(data[0]));
     }
   }, [search, data]);
 

--- a/web/src/pages/access/request/[id].tsx
+++ b/web/src/pages/access/request/[id].tsx
@@ -138,16 +138,16 @@ export const getWhenHelperText = (
   return "Choose a time in future for the access to be activated";
 };
 
-type Fields = {
+type RequestFormFields = {
   with?: CreateRequestWithSubRequest;
   timing?: RequestTiming;
   reason?: string;
 };
 
-type MyLocationGenerics = MakeGenerics<{
+export type RequestFormQueryParameters = MakeGenerics<{
   Search: {
     favorite?: string;
-  } & Fields;
+  } & RequestFormFields;
 }>;
 const AccessRequestForm = () => {
   const [loading, setLoading] = useState(false);
@@ -192,10 +192,10 @@ const AccessRequestForm = () => {
   } = methods;
 
   const toast = useToast();
-  const search = useSearch<MyLocationGenerics>();
+  const search = useSearch<RequestFormQueryParameters>();
 
   const [favorite, setFavorite] = useState<FavoriteDetail>();
-  const resetForm = (fields: Fields) => {
+  const resetForm = (fields: RequestFormFields) => {
     if (fields.timing) {
       setValue("timing.durationSeconds", fields.timing.durationSeconds);
       if (fields.timing.startTime) {
@@ -267,7 +267,7 @@ const AccessRequestForm = () => {
           return filteredWith;
         });
         // default value if there is no favorite is an empty selection
-        const fields: Fields = {
+        const fields: RequestFormFields = {
           with:
             filteredSearchWith === undefined || filteredSearchWith?.length == 0
               ? [{}]
@@ -345,7 +345,7 @@ const AccessRequestForm = () => {
   const location = useLocation();
   const fd = methods.watch();
   useEffect(() => {
-    const a: MyLocationGenerics = {
+    const a: RequestFormQueryParameters = {
       Search: {
         reason: getValues("reason"),
         with: (getValues("with") || [])


### PR DESCRIPTION
- Improves performance of the cache service by checking the provider schema first
- improves the performance and UX of the access rule form by not revalidating the cache every time
- Fixes bugs with validation on the provider step
- prevent using next buttons while provider schema is loading
- show a loading state while options are loading for arguments