### PR TITLE
Fix nil pointer, add retry backoff to invalidation

### DIFF
--- a/deploy/infra/lib/constructs/production-frontend-deployer.ts
+++ b/deploy/infra/lib/constructs/production-frontend-deployer.ts
@@ -33,7 +33,10 @@ export class ProductionFrontendDeployer extends Construct {
     );
     this._lambda = new lambda.Function(this, "Function", {
       code,
-      timeout: Duration.seconds(60),
+      // The frontend deployer has a 7 minute timeout
+      // internally, the deployer has a 5 minute retry backoff around the invalidation cloudfront method
+      // at worst execution would take around 5 mins 30s
+      timeout: Duration.seconds(60 * 7),
       environment: {
         CF_RELEASES_BUCKET: props.cfReleaseBucket,
         CF_RELEASES_FRONTEND_ASSET_OBJECT_PREFIX:

--- a/pkg/deploy/frontend.go
+++ b/pkg/deploy/frontend.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
@@ -18,6 +19,7 @@ import (
 	"github.com/common-fate/granted-approvals/pkg/config"
 	"github.com/magefile/mage/sh"
 	"github.com/segmentio/ksuid"
+	"github.com/sethvargo/go-retry"
 	"go.uber.org/zap"
 )
 
@@ -232,23 +234,32 @@ func DeployProductionFrontend(ctx context.Context, cfg config.FrontendDeployerCo
 
 	// Invalidate the distribution cache so the new files are used
 	cfClient := cloudfront.NewFromConfig(defaultAwsConfig)
-
-	// See the aws docs for caller reference, it just needs to be unique for every invalidation request
-	callerReference := ksuid.New().String()
-	res, err := cfClient.CreateInvalidation(ctx, &cloudfront.CreateInvalidationInput{
-
-		DistributionId: &cfg.CloudFrontDistributionID,
-		InvalidationBatch: &cfTypes.InvalidationBatch{
-			CallerReference: &callerReference,
-			Paths: &cfTypes.Paths{
-				Quantity: aws.Int32(1),
-				Items:    []string{"/*"},
+	var attempt int
+	// https://github.com/aws/aws-cdk/issues/15891#issuecomment-966456154
+	// See this issue which states that the cloudfront API can fail randomly during peak times due to internal AWS API limits.
+	// so try invalidating for up to 5 minutes with a backoff to ensure it has the best chance of working
+	b := retry.WithMaxDuration(time.Minute*5, retry.NewFibonacci(time.Second))
+	err = retry.Do(ctx, b, func(ctx context.Context) (err error) {
+		attempt += 1
+		// See the aws docs for caller reference, it just needs to be unique for every invalidation request
+		callerReference := ksuid.New().String()
+		res, err := cfClient.CreateInvalidation(ctx, &cloudfront.CreateInvalidationInput{
+			DistributionId: &cfg.CloudFrontDistributionID,
+			InvalidationBatch: &cfTypes.InvalidationBatch{
+				CallerReference: &callerReference,
+				Paths: &cfTypes.Paths{
+					Quantity: aws.Int32(1),
+					Items:    []string{"/*"},
+				},
 			},
-		},
+		})
+		if err != nil {
+			zap.S().Errorw("failed to invalidate cloudfront distribution due to an AWS API error, retrying", "attempt", attempt, "error", err)
+			return retry.RetryableError(err)
+		}
+		zap.S().Infow("successfully invalidated cloudfront distribution", "attempt", attempt, "cloudfront.id", cfg.CloudFrontDistributionID, "invalidation.id", res.Invalidation.Id)
+		return nil
 	})
-
-	zap.S().Infow("invalidated cloudfront distribution", "cloudfront.id", cfg.CloudFrontDistributionID, "invalidation.id", res.Invalidation.Id)
-
 	return err
 }
 


### PR DESCRIPTION
Based on some incidence of failure during deployment, we found that the Cloudfront invalidation API call can fail unexpectedly at peak times due to internal rate limiting of AWS.
See this issue, the recommended fix is to apply an additional retry backoff capability.
https://github.com/aws/aws-cdk/issues/15891#issuecomment-966456154

This PR adds a 5 minute Fibonacci backoff and increases the lambda timeout to match.

Looking at past executions, the lambda should normally take between 7 and 13 seconds to execute