### PR TITLE
Add fallback for request arguments when a provider no longer exists

### DIFF
--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -334,7 +334,6 @@ func (a *API) GetAccessInstructions(w http.ResponseWriter, r *http.Request, requ
 	ctx := r.Context()
 	q := storage.GetRequest{ID: requestId}
 	_, err := a.DB.Query(ctx, &q)
-
 	if err == ddb.ErrNoItems {
 		// we couldn't find the request
 		apio.Error(ctx, w, apio.NewRequestError(err, http.StatusNotFound))
@@ -348,19 +347,16 @@ func (a *API) GetAccessInstructions(w http.ResponseWriter, r *http.Request, requ
 		apio.ErrorString(ctx, w, "request has no grant", http.StatusBadRequest)
 		return
 	}
-	q.Result.Grant.With.AdditionalProperties["GrantId"] = q.ID
 
-	argsJSON, err := json.Marshal(q.Result.Grant.With)
+	args, err := json.Marshal(q.Result.Grant.With)
 	if err != nil {
 		apio.Error(ctx, w, err)
 		return
 	}
 
-	args := string(argsJSON)
-
 	res, err := a.AccessHandlerClient.GetAccessInstructionsWithResponse(ctx, q.Result.Grant.Provider, &ahtypes.GetAccessInstructionsParams{
 		Subject: q.Result.Grant.Subject,
-		Args:    args,
+		Args:    string(args),
 		GrantId: q.ID,
 	})
 	if err != nil {
@@ -372,7 +368,8 @@ func (a *API) GetAccessInstructions(w http.ResponseWriter, r *http.Request, requ
 	case http.StatusOK:
 		apio.JSON(ctx, w, res.JSON200, http.StatusOK)
 	case http.StatusNotFound:
-		apio.JSON(ctx, w, res.JSON404.Error, res.StatusCode())
+		// Not found error means that the provider does not exist, in this case, return an empty instructions response instead of 404
+		apio.JSON(ctx, w, ahtypes.AccessInstructions{}, http.StatusOK)
 	case http.StatusBadRequest:
 		apio.JSON(ctx, w, res.JSON400.Error, res.StatusCode())
 	default:


### PR DESCRIPTION
Fixes an issue where the API would return a 404 or 500 error when requesting a rule or instructions for an historical request where the access provider has since been removed.

This PR now implements fallback logic so that if a provider no longer exists, the request arguments are formed using the argument keys as labels/titles.

In a future PR we will introduce better fallback support to handle removing providers