### PR TITLE
Enforce only defined properties in granted-deployment.yml

### DIFF
--- a/pkg/deploy/config.go
+++ b/pkg/deploy/config.go
@@ -536,7 +536,9 @@ func LoadConfig(f string) (Config, error) {
 	}
 	defer fileRead.Close()
 	var dc Config
-	err = yaml.NewDecoder(fileRead).Decode(&dc)
+	decoder := yaml.NewDecoder(fileRead)
+	decoder.KnownFields(true)
+	err = decoder.Decode(&dc)
 	if err != nil {
 		return Config{}, err
 	}


### PR DESCRIPTION
Invalid properties not causes an error when running a gdeploy command which requires the config file.



<img width="685" alt="image" src="https://user-images.githubusercontent.com/14214200/202950943-973cecac-f2e7-40ee-988b-9846c5efeb5c.png">
