### PR TITLE
Add SamlIdentityProviderNameOutput to Cloudformation output

### DIFF
--- a/cmd/gdeploy/commands/identity/cognito-saml.go
+++ b/cmd/gdeploy/commands/identity/cognito-saml.go
@@ -10,8 +10,8 @@ import (
 )
 
 var CognitoSamlCommand = cli.Command{
-	Name:        "cognito-saml",
-	Description: "Generate a SAML Cognito url that can be used to login to Common Fate",
+	Name:        "saml-login-url",
+	Description: "Generate a SAML login URL that can be used to login to Common Fate when you are using SAML SSO",
 	Action: cli.ActionFunc(func(c *cli.Context) error {
 
 		ctx := c.Context

--- a/cmd/gdeploy/commands/identity/cognito-saml.go
+++ b/cmd/gdeploy/commands/identity/cognito-saml.go
@@ -1,0 +1,46 @@
+package identity
+
+// Command to generate a SAML Cognito url from gdeploy outputs
+
+import (
+	"fmt"
+
+	"github.com/common-fate/common-fate/pkg/deploy"
+	"github.com/urfave/cli/v2"
+)
+
+var CognitoSamlCommand = cli.Command{
+	Name:        "cognito-saml",
+	Description: "Generate a SAML Cognito url that can be used to login to Common Fate",
+	Action: cli.ActionFunc(func(c *cli.Context) error {
+
+		ctx := c.Context
+
+		dc, err := deploy.ConfigFromContext(ctx)
+		if err != nil {
+			return err
+		}
+		o, err := dc.LoadOutput(ctx)
+		if err != nil {
+			return err
+		}
+		UserPoolDomain := o.UserPoolDomain
+		SAMLIdentityProviderName := o.SAMLIdentityProviderName
+		CognitoClientID := o.CognitoClientID
+		FrontendDomainOutput := o.FrontendDomainOutput
+
+		// Check if any are nil
+		if UserPoolDomain == "" || SAMLIdentityProviderName == "" || CognitoClientID == "" || FrontendDomainOutput == "" {
+			return fmt.Errorf("missing required output values")
+		}
+
+		// Url format:
+		// https://$(UserPoolDomain)/authorize?response_type=code&identity_provider=$(SAMLIdentityProviderName)&client_id=$(CognitoClientID)&redirect_uri=https://$(FrontendDomainOutput)
+
+		url := fmt.Sprintf("https://%s/authorize?response_type=code&identity_provider=%s&client_id=%s&redirect_uri=https://%s", UserPoolDomain, SAMLIdentityProviderName, CognitoClientID, FrontendDomainOutput)
+
+		fmt.Println(url)
+
+		return nil
+	}),
+}

--- a/cmd/gdeploy/commands/identity/identity.go
+++ b/cmd/gdeploy/commands/identity/identity.go
@@ -23,6 +23,7 @@ var Command = cli.Command{
 	Subcommands: []*cli.Command{
 		&sso.SSOCommand,
 		&sync.SyncCommand,
+		&CognitoSamlCommand,
 		middleware.WithBeforeFuncs(&users.UsersCommand, PreventNonCognitoUsage()),
 		middleware.WithBeforeFuncs(&groups.GroupsCommand, PreventNonCognitoUsage()),
 	},

--- a/deploy/infra/lib/common-fate-stack-dev.ts
+++ b/deploy/infra/lib/common-fate-stack-dev.ts
@@ -139,6 +139,7 @@ export class CommonFateStackDev extends cdk.Stack {
       EventBusArn: events.getEventBus().eventBusArn,
       EventBusSource: events.getEventBusSourceName(),
       IdpSyncFunctionName: appBackend.getIdpSync().getFunctionName(),
+      IdentityProvider: webUserPool.getIdpType(),
       Region: this.region,
       PaginationKMSKeyARN: appBackend.getKmsKeyArn(),
       AccessHandlerExecutionRoleARN: accessHandler.getAccessHandlerExecutionRoleArn(),

--- a/deploy/infra/lib/common-fate-stack-dev.ts
+++ b/deploy/infra/lib/common-fate-stack-dev.ts
@@ -139,7 +139,8 @@ export class CommonFateStackDev extends cdk.Stack {
       EventBusArn: events.getEventBus().eventBusArn,
       EventBusSource: events.getEventBusSourceName(),
       IdpSyncFunctionName: appBackend.getIdpSync().getFunctionName(),
-      SAMLIdentityProviderName: webUserPool.getIdpType(),
+      SAMLIdentityProviderName:
+        webUserPool.getSamlUserPoolClient()?.getUserPoolName() || "",
       Region: this.region,
       PaginationKMSKeyARN: appBackend.getKmsKeyArn(),
       AccessHandlerExecutionRoleARN: accessHandler.getAccessHandlerExecutionRoleArn(),

--- a/deploy/infra/lib/common-fate-stack-dev.ts
+++ b/deploy/infra/lib/common-fate-stack-dev.ts
@@ -139,7 +139,7 @@ export class CommonFateStackDev extends cdk.Stack {
       EventBusArn: events.getEventBus().eventBusArn,
       EventBusSource: events.getEventBusSourceName(),
       IdpSyncFunctionName: appBackend.getIdpSync().getFunctionName(),
-      IdentityProvider: webUserPool.getIdpType(),
+      SAMLIdentityProviderName: webUserPool.getIdpType(),
       Region: this.region,
       PaginationKMSKeyARN: appBackend.getKmsKeyArn(),
       AccessHandlerExecutionRoleARN: accessHandler.getAccessHandlerExecutionRoleArn(),

--- a/deploy/infra/lib/common-fate-stack-prod.ts
+++ b/deploy/infra/lib/common-fate-stack-prod.ts
@@ -274,7 +274,7 @@ export class CommonFateStackProd extends cdk.Stack {
       EventBusArn: events.getEventBus().eventBusArn,
       EventBusSource: events.getEventBusSourceName(),
       IdpSyncFunctionName: appBackend.getIdpSync().getFunctionName(),
-      IdentityProvider: webUserPool.getIdpType(),
+      SAMLIdentityProviderName: webUserPool.getIdpType(),
       Region: this.region,
       PaginationKMSKeyARN: appBackend.getKmsKeyArn(),
       AccessHandlerExecutionRoleARN: accessHandler.getAccessHandlerExecutionRoleArn(),

--- a/deploy/infra/lib/common-fate-stack-prod.ts
+++ b/deploy/infra/lib/common-fate-stack-prod.ts
@@ -274,7 +274,8 @@ export class CommonFateStackProd extends cdk.Stack {
       EventBusArn: events.getEventBus().eventBusArn,
       EventBusSource: events.getEventBusSourceName(),
       IdpSyncFunctionName: appBackend.getIdpSync().getFunctionName(),
-      SAMLIdentityProviderName: webUserPool.getIdpType(),
+      SAMLIdentityProviderName:
+        webUserPool.getSamlUserPoolClient()?.getUserPoolName() || "",
       Region: this.region,
       PaginationKMSKeyARN: appBackend.getKmsKeyArn(),
       AccessHandlerExecutionRoleARN: accessHandler.getAccessHandlerExecutionRoleArn(),

--- a/deploy/infra/lib/common-fate-stack-prod.ts
+++ b/deploy/infra/lib/common-fate-stack-prod.ts
@@ -274,6 +274,7 @@ export class CommonFateStackProd extends cdk.Stack {
       EventBusArn: events.getEventBus().eventBusArn,
       EventBusSource: events.getEventBusSourceName(),
       IdpSyncFunctionName: appBackend.getIdpSync().getFunctionName(),
+      IdentityProvider: webUserPool.getIdpType(),
       Region: this.region,
       PaginationKMSKeyARN: appBackend.getKmsKeyArn(),
       AccessHandlerExecutionRoleARN: accessHandler.getAccessHandlerExecutionRoleArn(),

--- a/deploy/infra/lib/helpers/outputs.ts
+++ b/deploy/infra/lib/helpers/outputs.ts
@@ -24,6 +24,7 @@ export type StackOutputs = {
   EventBusArn: string;
   EventBusSource: string;
   IdpSyncFunctionName: string;
+  IdentityProvider: string;
   Region: string;
   PaginationKMSKeyARN: string;
   AccessHandlerExecutionRoleARN: string;

--- a/deploy/infra/lib/helpers/outputs.ts
+++ b/deploy/infra/lib/helpers/outputs.ts
@@ -24,7 +24,7 @@ export type StackOutputs = {
   EventBusArn: string;
   EventBusSource: string;
   IdpSyncFunctionName: string;
-  IdentityProvider: string;
+  SAMLIdentityProviderName: string;
   Region: string;
   PaginationKMSKeyARN: string;
   AccessHandlerExecutionRoleARN: string;

--- a/deploy/infra/test/stack-outputs.ts
+++ b/deploy/infra/test/stack-outputs.ts
@@ -27,7 +27,7 @@ const testOutputs: StackOutputs = {
   EventBusArn: "abcdefg",
   EventBusSource: "abcdefg",
   IdpSyncFunctionName: "abcdefg",
-  IdentityProvider: "abcdefg",
+  SAMLIdentityProviderName: "abcdefg",
   Region: "abcdefg",
   PaginationKMSKeyARN: "abcdefg",
   AccessHandlerExecutionRoleARN: "abcdefg",

--- a/deploy/infra/test/stack-outputs.ts
+++ b/deploy/infra/test/stack-outputs.ts
@@ -27,6 +27,7 @@ const testOutputs: StackOutputs = {
   EventBusArn: "abcdefg",
   EventBusSource: "abcdefg",
   IdpSyncFunctionName: "abcdefg",
+  IdentityProvider: "abcdefg",
   Region: "abcdefg",
   PaginationKMSKeyARN: "abcdefg",
   AccessHandlerExecutionRoleARN: "abcdefg",

--- a/pkg/deploy/output.go
+++ b/pkg/deploy/output.go
@@ -19,6 +19,7 @@ import (
 // Output is the output from deploying the CDK stack to AWS.
 type Output struct {
 	CognitoClientID               string `json:"CognitoClientID"`
+	IdentityProvider              string `json:"IdentityProvider"`
 	CloudFrontDomain              string `json:"CloudFrontDomain"`
 	FrontendDomainOutput          string `json:"FrontendDomainOutput"`
 	CloudFrontDistributionID      string `json:"CloudFrontDistributionID"`

--- a/pkg/deploy/output.go
+++ b/pkg/deploy/output.go
@@ -19,7 +19,7 @@ import (
 // Output is the output from deploying the CDK stack to AWS.
 type Output struct {
 	CognitoClientID               string `json:"CognitoClientID"`
-	IdentityProvider              string `json:"IdentityProvider"`
+	SAMLIdentityProviderName      string `json:"SAMLIdentityProviderName"`
 	CloudFrontDomain              string `json:"CloudFrontDomain"`
 	FrontendDomainOutput          string `json:"FrontendDomainOutput"`
 	CloudFrontDistributionID      string `json:"CloudFrontDistributionID"`

--- a/pkg/deploy/output_test.go
+++ b/pkg/deploy/output_test.go
@@ -58,6 +58,7 @@ func TestOutputStructMatchesTSType(t *testing.T) {
 		EventBusArn:                   "abcdefg",
 		EventBusSource:                "abcdefg",
 		IdpSyncFunctionName:           "abcdefg",
+		IdentityProvider:              "abcdefg",
 		Region:                        "abcdefg",
 		PaginationKMSKeyARN:           "abcdefg",
 		AccessHandlerExecutionRoleARN: "abcdefg",
@@ -113,6 +114,7 @@ func TestOutput_Get(t *testing.T) {
 		EventBusArn                   string
 		EventBusSource                string
 		IdpSyncFunctionName           string
+		IdentityProvider              string
 		Region                        string
 		PaginationKMSKeyARN           string
 		AccessHandlerExecutionRoleARN string
@@ -170,6 +172,7 @@ func TestOutput_Get(t *testing.T) {
 				EventBusArn:                   tt.fields.EventBusArn,
 				EventBusSource:                tt.fields.EventBusSource,
 				IdpSyncFunctionName:           tt.fields.IdpSyncFunctionName,
+				IdentityProvider:              tt.fields.IdentityProvider,
 				Region:                        tt.fields.Region,
 				PaginationKMSKeyARN:           tt.fields.PaginationKMSKeyARN,
 				AccessHandlerExecutionRoleARN: tt.fields.AccessHandlerExecutionRoleARN,

--- a/pkg/deploy/output_test.go
+++ b/pkg/deploy/output_test.go
@@ -58,7 +58,7 @@ func TestOutputStructMatchesTSType(t *testing.T) {
 		EventBusArn:                   "abcdefg",
 		EventBusSource:                "abcdefg",
 		IdpSyncFunctionName:           "abcdefg",
-		IdentityProvider:              "abcdefg",
+		SAMLIdentityProviderName:      "abcdefg",
 		Region:                        "abcdefg",
 		PaginationKMSKeyARN:           "abcdefg",
 		AccessHandlerExecutionRoleARN: "abcdefg",
@@ -114,7 +114,7 @@ func TestOutput_Get(t *testing.T) {
 		EventBusArn                   string
 		EventBusSource                string
 		IdpSyncFunctionName           string
-		IdentityProvider              string
+		SAMLIdentityProviderName      string
 		Region                        string
 		PaginationKMSKeyARN           string
 		AccessHandlerExecutionRoleARN string
@@ -172,7 +172,7 @@ func TestOutput_Get(t *testing.T) {
 				EventBusArn:                   tt.fields.EventBusArn,
 				EventBusSource:                tt.fields.EventBusSource,
 				IdpSyncFunctionName:           tt.fields.IdpSyncFunctionName,
-				IdentityProvider:              tt.fields.IdentityProvider,
+				SAMLIdentityProviderName:      tt.fields.SAMLIdentityProviderName,
 				Region:                        tt.fields.Region,
 				PaginationKMSKeyARN:           tt.fields.PaginationKMSKeyARN,
 				AccessHandlerExecutionRoleARN: tt.fields.AccessHandlerExecutionRoleARN,


### PR DESCRIPTION
This command adds a gdeploy output for `SAMLIdentityProviderName`
This is used to assist with the SAML setup for https://github.com/common-fate/docs/pull/161
