### PR TITLE
add one login as a sso provider in registry

### DIFF
--- a/deploy/infra/lib/helpers/registry.ts
+++ b/deploy/infra/lib/helpers/registry.ts
@@ -8,6 +8,8 @@ export const IdentityProviderRegistry = {
   AzureAD: "azure",
   Google: "google",
   AWSSSO: "aws-sso",
+  OneLogin: "one-login",
 } as const;
 
-export type IdentityProviderTypes = typeof IdentityProviderRegistry[keyof typeof IdentityProviderRegistry];
+export type IdentityProviderTypes =
+  typeof IdentityProviderRegistry[keyof typeof IdentityProviderRegistry];


### PR DESCRIPTION
Adds OneLogin (`one-login`) as an accepted CloudFormation parameter for the identity provider.