### PR TITLE
CF-537: pagination fix on User/Group multi selects

### DIFF
--- a/web/src/components/forms/access-rule/components/Select.tsx
+++ b/web/src/components/forms/access-rule/components/Select.tsx
@@ -33,7 +33,7 @@ export const UserSelect: React.FC<BaseSelectProps> = (props) => {
   const [items, setItems] = useState<User[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
-  const fetchUsers = async (nextInput?: string) => {
+  async function fetchUsers(nextInput?: string) {
     // if there are items, and no nextInput then we are done
     if (!nextInput && items.length !== 0) {
       setIsLoading(false);
@@ -47,17 +47,16 @@ export const UserSelect: React.FC<BaseSelectProps> = (props) => {
 
     if (users) {
       users && setItems((currItems) => [...currItems, ...users]);
-      // setNextToken(next);
       if (next) {
-        fetchUsers(next);
+        void fetchUsers(next);
       } else {
         setIsLoading(false);
       }
     }
-  };
+  }
 
   useEffect(() => {
-    fetchUsers();
+    void fetchUsers();
     return () => {
       setItems([]);
       setIsLoading(true);
@@ -70,6 +69,8 @@ export const UserSelect: React.FC<BaseSelectProps> = (props) => {
         .map((u) => {
           return { value: u.id, label: u.email };
         })
+        // filter out dupes:
+        .filter((v, i, a) => a.findIndex((t) => t.value === v.value) === i)
         .sort((a, b) => a.label.localeCompare(b.label)) ?? [],
     [items]
   );
@@ -89,7 +90,8 @@ export const GroupSelect: React.FC<GroupSelectProps> = (props) => {
   const [items, setItems] = useState<Group[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
-  const fetchGroups = async (nextInput?: string) => {
+  // const fetchGroups = async (nextInput?: string) => { // recreate but mark as void
+  async function fetchGroups(nextInput?: string) {
     // if there are items, and no nextInput then we are done
     if (!nextInput && items.length !== 0) {
       setIsLoading(false);
@@ -103,17 +105,16 @@ export const GroupSelect: React.FC<GroupSelectProps> = (props) => {
     });
     if (groups) {
       groups && setItems((currItems) => [...currItems, ...groups]);
-      // setNextToken(next);
       if (next) {
-        fetchGroups(next);
+        void fetchGroups(next);
       } else {
         setIsLoading(false);
       }
     }
-  };
+  }
 
   useEffect(() => {
-    fetchGroups();
+    void fetchGroups();
     return () => {
       setItems([]);
       setIsLoading(true);


### PR DESCRIPTION
* also includes fix for Group membership labels

## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Please see latest linear comment: https://linear.app/common-fate/issue/CF-537/users-and-groups-ui-select-elements-do-not-handle-pagination

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## Testing

<!-- Please describe how the reviewer can test the changes. Also include steps to reproduce the testing environment. -->

I think 1) the loom, and 2) code review should suffice for testing. Otherwise feel free to spin up a dev instance, create 50+ users/groups and test the changes

```
export const create500Groups = async () => {
  for (let i = 0; i < 500; i++) {
    // const group = await adminCreateGroup({
    //   name: `Group ${i}`,
    //   description: `Group ${i} description`,
    //   members: [],
    // });
    // console.log(group);
    const user = await adminCreateUser({
      email: `test${i}@mail.com`,
      firstName: `Test${i}`,
      lastName: `User${i}`,
      isAdmin: false,
    });
    console.log(user);
  }
};

```

## Checklist before requesting a review

<!-- Please tick off this checklist to ensure you have met all requirements prior to PR -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Do we need to implement analytics? If so, have you followed up with @ellie-narducci?
- [ ] I have made corresponding changes to the documentation, docs PR has been linked.
- [ ] New and existing unit tests pass with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
