### PR TITLE
CF-529: admin menu dark mode fix

### DIFF
--- a/web/src/components/nav/AdminNavbar.tsx
+++ b/web/src/components/nav/AdminNavbar.tsx
@@ -138,7 +138,6 @@ export const AdminNavbar: React.FC = () => {
                         color="gray.800"
                         _hover={{
                           cursor: "auto",
-
                           backgroundColor: "gray.50",
                         }}
                         onClick={(e) => {
@@ -154,7 +153,6 @@ export const AdminNavbar: React.FC = () => {
                         onClick={auth.initiateSignOut}
                         _hover={{
                           cursor: "auto",
-
                           backgroundColor: "gray.50",
                         }}
                       >

--- a/web/src/components/nav/AdminNavbar.tsx
+++ b/web/src/components/nav/AdminNavbar.tsx
@@ -15,6 +15,7 @@ import {
   Input,
   InputGroup,
   InputLeftElement,
+  LightMode,
   Link as ChakraLink,
   Menu,
   MenuButton,
@@ -134,7 +135,12 @@ export const AdminNavbar: React.FC = () => {
                     </MenuButton>
                     <MenuList _dark={{ borderColor: "gray.500" }}>
                       <MenuItem
-                        _hover={{ cursor: "auto", backgroundColor: "gray.700" }}
+                        color="gray.800"
+                        _hover={{
+                          cursor: "auto",
+
+                          backgroundColor: "gray.50",
+                        }}
                         onClick={(e) => {
                           e.preventDefault();
                         }}
@@ -142,9 +148,15 @@ export const AdminNavbar: React.FC = () => {
                         {user.user?.email}
                       </MenuItem>
                       <MenuItem
+                        color="gray.800"
                         data-testid="logout-button"
                         icon={<DoorIcon color={"gray.400"} />}
                         onClick={auth.initiateSignOut}
+                        _hover={{
+                          cursor: "auto",
+
+                          backgroundColor: "gray.50",
+                        }}
                       >
                         Sign out
                       </MenuItem>


### PR DESCRIPTION
## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
![image](https://user-images.githubusercontent.com/21688404/213356678-3f7a8c4b-42f3-4905-99da-b75621092bef.png)
<img width="256" alt="image" src="https://user-images.githubusercontent.com/21688404/213356734-6effd46d-d7de-4169-897e-943c1a104fa3.png">


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Issue and Documentation

<!-- Please link the appropriate Linear/GitHub issues as well as any supporting Notion documentation. Notion documentation should include a Loom. Also include a link to the documentation PR if relevant. -->

- https://linear.app/common-fate/issue/CF-529/nav-text-is-not-visible-in-admin-ui
 

## Checklist before requesting a review

<!-- Please tick off this checklist to ensure you have met all requirements prior to PR -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Do we need to implement analytics? If so, have you followed up with @ellie-narducci?
- [ ] I have made corresponding changes to the documentation, docs PR has been linked.
- [ ] New and existing unit tests pass with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
