### PR TITLE
refactor upsert/delete

### DIFF
--- a/cmd/gdeploy/commands/cache/cache.go
+++ b/cmd/gdeploy/commands/cache/cache.go
@@ -1,7 +1,7 @@
 package cache
 
 import (
-	"github.com/common-fate/common-fate/cmd/gdeploy/commands/identity/sync"
+	"github.com/common-fate/common-fate/cmd/gdeploy/commands/cache/sync"
 	"github.com/urfave/cli/v2"
 )
 

--- a/cmd/gdeploy/commands/cache/sync/sync.go
+++ b/cmd/gdeploy/commands/cache/sync/sync.go
@@ -45,7 +45,7 @@ var SyncCommand = cli.Command{
 
 		lambdaClient := lambda.NewFromConfig(cfg)
 		res, err := lambdaClient.Invoke(ctx, &lambda.InvokeInput{
-			FunctionName:   &o.IdpSyncFunctionName,
+			FunctionName:   &o.CacheSyncFunctionName,
 			InvocationType: types.InvocationTypeRequestResponse,
 			Payload:        []byte("{}"),
 		})

--- a/pkg/cache/provider_arg_group.go
+++ b/pkg/cache/provider_arg_group.go
@@ -22,6 +22,9 @@ type ProviderArgGroupOption struct {
 	Description *string  `json:"description" dynamodbav:"description"`
 }
 
+func (r ProviderArgGroupOption) Key() string {
+	return keys.ProviderArgGroupOption.SK1(r.Provider, r.Arg, r.Group, r.Value)
+}
 func (r *ProviderArgGroupOption) DDBKeys() (ddb.Keys, error) {
 	keys := ddb.Keys{
 		PK: keys.ProviderArgGroupOption.PK1,

--- a/pkg/cache/provider_option.go
+++ b/pkg/cache/provider_option.go
@@ -19,6 +19,10 @@ type ProviderOption struct {
 	Description *string `json:"description" dynamodbav:"description"`
 }
 
+func (r ProviderOption) Key() string {
+	return keys.ProviderOption.SK1(r.Provider, r.Arg, r.Value)
+}
+
 func (r *ProviderOption) DDBKeys() (ddb.Keys, error) {
 	keys := ddb.Keys{
 		PK: keys.ProviderOption.PK1,


### PR DESCRIPTION
## Describe your changes

- Fix an issue where cache sync would delete entries before new entries were available by changing the order of operations, and only deleting items that no longer exist.
- Fixes issue with `gdeploy cache sync` command pointing to the IDP sync rather than the provider cache

## Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)

## Issue and Documentation

- https://linear.app/common-fate/issue/SOL-35/fix-cache-sync-deletion-issue

## Testing

1. verified that the cache still syncs as expected

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Do we need to implement analytics? If so, have you followed up with @ellie-narducci?
- [ ] I have made corresponding changes to the documentation, docs PR has been linked.
- [ ] New and existing unit tests pass with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
