### PR TITLE
add debug logging for Okta IDP sync

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.50.0
-          args: --timeout=4m
+          args: --timeout=10m
 
   test-frontend:
     name: Test NodeJS

--- a/cmd/gdeploy/main.go
+++ b/cmd/gdeploy/main.go
@@ -20,10 +20,8 @@ import (
 	"github.com/common-fate/common-fate/internal/build"
 	"github.com/common-fate/common-fate/pkg/deploy"
 	"github.com/fatih/color"
-	"github.com/mattn/go-colorable"
 	"github.com/urfave/cli/v2"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 func main() {
@@ -66,16 +64,8 @@ func main() {
 		},
 	}
 
-	dec := zap.NewDevelopmentEncoderConfig()
-	dec.EncodeTime = nil
-	dec.EncodeLevel = zapcore.CapitalColorLevelEncoder
-	log := zap.New(zapcore.NewCore(
-		zapcore.NewConsoleEncoder(dec),
-		zapcore.AddSync(colorable.NewColorableStdout()),
-		zapcore.DebugLevel,
-	))
-
-	zap.ReplaceGlobals(log)
+	clio.SetLevelFromEnv("CF_LOG", "GRANTED_LOG")
+	zap.ReplaceGlobals(clio.G())
 
 	err := internal.PrintAnalyticsNotice(false)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/hashicorp/go-memdb v1.3.3
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/magefile/mage v1.13.0
-	github.com/mattn/go-colorable v0.1.12
 	github.com/okta/okta-sdk-golang/v2 v2.13.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pkg/errors v0.9.1
@@ -93,6 +92,7 @@ require (
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/labstack/echo/v4 v4.7.2 // indirect
 	github.com/labstack/gommon v0.3.1 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect

--- a/pkg/deploy/config.go
+++ b/pkg/deploy/config.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/segmentio/ksuid"
 	"github.com/urfave/cli/v2"
-	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 )
 
@@ -245,16 +244,8 @@ func UnmarshalProviderMap(data string) (ProviderMap, error) {
 // RunConfigTest runs ConfigTest() if it is implemented on the interface
 func RunConfigTest(ctx context.Context, testable interface{}) error {
 	if tester, ok := testable.(gconfig.Tester); ok {
-		si := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
-		si.Suffix = " running tests using this configuration."
-		si.Writer = os.Stderr
-		si.Start()
-		defer si.Stop()
+		clio.Info("running tests using this configuration...")
 
-		// disable zap logging which can be emitted by components intended to run in a server environement.
-		// after the test, the original logger is restored
-		restore := zap.ReplaceGlobals(zap.NewNop())
-		defer restore()
 		if initer, ok := testable.(gconfig.Initer); ok {
 			err := initer.Init(ctx)
 			if err != nil {
@@ -265,7 +256,6 @@ func RunConfigTest(ctx context.Context, testable interface{}) error {
 		if err != nil {
 			return err
 		}
-		si.Stop()
 		clio.Success("Configuration tests passed!")
 	}
 	return nil

--- a/pkg/identity/identitysync/okta.go
+++ b/pkg/identity/identitysync/okta.go
@@ -64,6 +64,11 @@ func (o *OktaSync) idpUserFromOktaUser(ctx context.Context, oktaUser *okta.User)
 
 	log.Debugw("converting okta user to internal user", "oktaUser", string(userJSON))
 
+	// errors returned here are propagated up to the IDP sync function and cause the entire function to fail.
+	// if for any reason the Okta user profile doesn't contain "firstName" and "lastName" fields on the JSON object,
+	// we log an error and set them to an empty string to prevent the entire function failing.
+	// The only field which we MUST have set is the user email address.
+
 	firstName, ok := (*oktaUser.Profile)["firstName"].(string)
 	if !ok {
 		log.Error("okta profile had no firstName")


### PR DESCRIPTION
Adds additional debugging logic so that 

```
CF_LOG=debug gdeploy identity sso enable
```

can be run to help identify issues during IDP sync.