### PR TITLE
infra: add CLI app client dependency on user pools

### DIFF
--- a/deploy/infra/lib/constructs/app-user-pool.ts
+++ b/deploy/infra/lib/constructs/app-user-pool.ts
@@ -191,10 +191,9 @@ export class WebUserPool extends Construct {
         callbackUrls: ["http://localhost:18900/auth/cognito/callback"],
       },
     });
-    this._cliAppClient.node.addDependency(
-      this._samlUserPoolClient,
-      cognitoWebClient
-    );
+    const rawCliAppClient = this._cliAppClient.node
+      .defaultChild as CfnUserPoolClient;
+    rawCliAppClient.addDependsOn(this._samlUserPoolClient.getIdp());
   }
 
   getCLIAppClient(): cognito.IUserPoolClient {
@@ -307,6 +306,9 @@ export class SamlUserPoolClient extends Construct {
     // adding this depends on to ensure that the user pool client is not created until the saml CfnUserPoolIdentityProvider exists
     // this avoids an error "The provider <PROVIDER NAME> does not exist for User Pool <POOL_ID>"
     c.addDependsOn(this._idp);
+  }
+  getIdp(): CfnUserPoolIdentityProvider {
+    return this._idp;
   }
   getUserPoolClient(): cognito.UserPoolClient {
     return this._userPoolClient;

--- a/deploy/infra/lib/constructs/app-user-pool.ts
+++ b/deploy/infra/lib/constructs/app-user-pool.ts
@@ -191,7 +191,12 @@ export class WebUserPool extends Construct {
         callbackUrls: ["http://localhost:18900/auth/cognito/callback"],
       },
     });
+    this._cliAppClient.node.addDependency(
+      this._samlUserPoolClient,
+      cognitoWebClient
+    );
   }
+
   getCLIAppClient(): cognito.IUserPoolClient {
     return this._cliAppClient;
   }

--- a/deploy/infra/lib/constructs/app-user-pool.ts
+++ b/deploy/infra/lib/constructs/app-user-pool.ts
@@ -171,7 +171,11 @@ export class WebUserPool extends Construct {
     const idp = cdk.Fn.conditionIf(
       createCognitoResources.logicalId,
       "COGNITO",
-      props.idpType
+      // the ref of the Cognito IDP is its name
+      // this ensures that the IDP is provisioned before the app client is created
+      // this avoids an error "The provider <PROVIDER NAME> does not exist for User Pool <POOL_ID>"
+      // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpoolidentityprovider.html#aws-resource-cognito-userpoolidentityprovider-return-values
+      cdk.Fn.ref(this._samlUserPoolClient.getIdp().logicalId)
     ).toString();
 
     // create an app client for the CLI
@@ -191,9 +195,6 @@ export class WebUserPool extends Construct {
         callbackUrls: ["http://localhost:18900/auth/cognito/callback"],
       },
     });
-    const rawCliAppClient = this._cliAppClient.node
-      .defaultChild as CfnUserPoolClient;
-    rawCliAppClient.addDependsOn(this._samlUserPoolClient.getIdp());
   }
 
   getCLIAppClient(): cognito.IUserPoolClient {


### PR DESCRIPTION
Fixes a CloudFormation dependency issue when enabling SSO on a deployment which was resulting in `The provider <PROVIDER NAME> does not exist for User Pool <POOL_ID>` errors.