### PR TITLE
CF-605: fix menulist filtering issue

### DIFF
--- a/web/src/components/tables/RequestsFilterMenu.tsx
+++ b/web/src/components/tables/RequestsFilterMenu.tsx
@@ -37,6 +37,18 @@ export const RequestsFilterMenu: React.FC<{
           defaultValue="all"
           title="View option"
           type="radio"
+          value={
+            // map the status input to a value so that the MenuList hydrates the current state
+            status === "PENDING"
+              ? "pend"
+              : status === "DECLINED"
+              ? "den"
+              : status === "APPROVED"
+              ? "apr"
+              : status === "CANCELLED"
+              ? "can"
+              : "all"
+          }
           onChange={(e) => {
             switch (e) {
               case "pend":


### PR DESCRIPTION
## Describe your changes

> The dropdown is not correctly indexed and shows ‘pending only’ when “all” is selected.

This should fix the issue described. The menu list wasn't getting the input value passed down to the Options/List child component. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Issue and Documentation

- https://linear.app/common-fate/issue/CF-605/access-requests-filtering-issue

## Testing

I've confirmed that the undesired behaviour has been fixed. I have however noticed additional strange behaviour. In certain states the value seems to hang on screen. This could be due to async logic in the navigate/router, or API query. I.e. 
```
        <RequestsFilterMenu
          onChange={(s) =>
            navigate({
              search: (old) => ({
                ...old,
                status: s?.toLowerCase() as Lowercase<RequestStatus>,
              }),
            })
          }
```

## Checklist before requesting a review

<!-- Please tick off this checklist to ensure you have met all requirements prior to PR -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Do we need to implement analytics? If so, have you followed up with @ellie-narducci?
- [ ] I have made corresponding changes to the documentation, docs PR has been linked.
- [ ] New and existing unit tests pass with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
