### PR TITLE
fix terraform group mapping

### DIFF
--- a/governance/pkg/api/accessrule.go
+++ b/governance/pkg/api/accessrule.go
@@ -63,48 +63,6 @@ func (a *API) GovCreateAccessRule(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	//create a mapping of usernames to user ids
-
-	listUsers := storage.ListUsers{}
-
-	_, err = a.DB.Query(ctx, &listUsers)
-	if err != nil {
-		apio.Error(ctx, w, err)
-		return
-	}
-	listGroups := &storage.ListGroups{}
-	_, err = a.DB.Query(ctx, listGroups)
-	if err != nil {
-		apio.Error(ctx, w, err)
-		return
-	}
-
-	userMap := make(map[string]string)
-	groupMap := make(map[string]string)
-
-	for _, u := range listUsers.Result {
-		userMap[u.Email] = u.ID
-	}
-	for _, g := range listGroups.Result {
-		groupMap[g.Name] = g.ID
-	}
-
-	for i, group := range createRequest.Groups {
-		createRequest.Groups[i] = groupMap[group]
-	}
-
-	//approval may come in nil if not applied
-
-	for i, group := range createRequest.Approval.Groups {
-		createRequest.Approval.Groups[i] = groupMap[group]
-
-	}
-
-	for i, user := range createRequest.Approval.Users {
-		createRequest.Approval.Users[i] = userMap[user]
-
-	}
-
 	c, err := a.Rules.CreateAccessRule(ctx, "bot_governance_api", createRequest)
 
 	if err == rulesvc.ErrRuleIdAlreadyExists {

--- a/governance/pkg/api/accessrule.go
+++ b/governance/pkg/api/accessrule.go
@@ -115,46 +115,6 @@ func (a *API) GovUpdateAccessRule(w http.ResponseWriter, r *http.Request, ruleId
 	}
 	rule = ruleq.Result
 
-	//create a mapping of usernames to user ids
-
-	listUsers := storage.ListUsers{}
-
-	_, err = a.DB.Query(ctx, &listUsers)
-	if err != nil {
-		apio.Error(ctx, w, err)
-		return
-	}
-	listGroups := &storage.ListGroups{}
-	_, err = a.DB.Query(ctx, listGroups)
-	if err != nil {
-		apio.Error(ctx, w, err)
-		return
-	}
-
-	userMap := make(map[string]string)
-	groupMap := make(map[string]string)
-
-	for _, u := range listUsers.Result {
-		userMap[u.Email] = u.ID
-	}
-	for _, g := range listGroups.Result {
-		groupMap[g.Name] = g.ID
-	}
-
-	for i, group := range updateRequest.Groups {
-		updateRequest.Groups[i] = groupMap[group]
-	}
-
-	for i, group := range updateRequest.Approval.Groups {
-		updateRequest.Approval.Groups[i] = groupMap[group]
-
-	}
-
-	for i, user := range updateRequest.Approval.Users {
-		updateRequest.Approval.Users[i] = userMap[user]
-
-	}
-
 	updatedRule, err := a.Rules.UpdateRule(ctx, &rulesvc.UpdateOpts{
 		UpdaterID:     "bot_governance_api",
 		Rule:          *rule,


### PR DESCRIPTION
## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where groups mapped from an IDP were not added properly on an Access Rule. This is because the IDP groups have a name which is different to their ID. The mapping logic assumed that the name is identical to the group ID, which is only the case in Cognito groups.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issue and Documentation

<!-- Please link the appropriate Linear/GitHub issues as well as any supporting Notion documentation. Notion documentation should include a Loom. Also include a link to the documentation PR if relevant. -->

-

## Testing

<!-- Please describe how the reviewer can test the changes. Also include steps to reproduce the testing environment. -->

1. Tested via a Terraform-based deployment of Common Fate - verified in the deployment that this resolves the issue.

