### PR TITLE
AWS SSO IDP: support an external ID

### DIFF
--- a/pkg/cfaws/credentials_cache.go
+++ b/pkg/cfaws/credentials_cache.go
@@ -20,6 +20,14 @@ func WithRoleSessionName(rsn string) AssumeRoleCredentialProviderOptFunc {
 	}
 }
 
+// WithExternalID adds an External ID to the role assumption.
+// https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
+func WithExternalID(externalID string) AssumeRoleCredentialProviderOptFunc {
+	return func(f *AssumeRoleCredentialProviderOpts) {
+		f.ExternalId = &externalID
+	}
+}
+
 // NewAssumeRoleCredentialsCache helps making a credential provider for an assume role arn
 func NewAssumeRoleCredentialsCache(ctx context.Context, roleARN string, opts ...AssumeRoleCredentialProviderOptFunc) *aws.CredentialsCache {
 	cfg := AssumeRoleCredentialProviderOpts{

--- a/pkg/cfaws/credentials_cache.go
+++ b/pkg/cfaws/credentials_cache.go
@@ -24,7 +24,11 @@ func WithRoleSessionName(rsn string) AssumeRoleCredentialProviderOptFunc {
 // https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
 func WithExternalID(externalID string) AssumeRoleCredentialProviderOptFunc {
 	return func(f *AssumeRoleCredentialProviderOpts) {
-		f.ExternalId = &externalID
+		// empty external IDs cause role assumption errors,
+		// so only set it if it's not an empty string.
+		if externalID != "" {
+			f.ExternalId = &externalID
+		}
 	}
 }
 


### PR DESCRIPTION
Adds support for using an External ID when assuming the role to read AWS SSO IDP data:

```yaml
version: 2
deployment:
  parameters:
    IdentityProviderType: aws-sso
    SamlSSOMetadataURL: <SAML metadata URL>
    IdentityConfiguration:
      aws-sso:
        externalId: "some-external-id"
        identityStoreId: d-123455678
        identityStoreRoleArn: arn:aws:iam::123456789012:role/idp-read-role
        region: ap-southeast-2
```

Tested manually in UAT and this doesn't break the existing identity sync function if it's not provided.