### PR TITLE
add support for cloudformation tags

### DIFF
--- a/pkg/deploy/config.go
+++ b/pkg/deploy/config.go
@@ -75,8 +75,9 @@ type Deployment struct {
 	// Note that the S3 bucket must be in the same region as the 'Region' parameter.
 	Release string `yaml:"release"`
 	// Dev is set to true for internal development deployments only.
-	Dev        *bool      `yaml:"dev,omitempty"`
-	Parameters Parameters `yaml:"parameters"`
+	Dev        *bool             `yaml:"dev,omitempty"`
+	Parameters Parameters        `yaml:"parameters"`
+	Tags       map[string]string `yaml:"tags,omitempty"`
 }
 
 type ProviderMap map[string]Provider

--- a/pkg/deploy/deploy_cfn.go
+++ b/pkg/deploy/deploy_cfn.go
@@ -37,7 +37,7 @@ func (c *Config) DeployCloudFormation(ctx context.Context, confirm bool) (string
 		return "", err
 	}
 
-	changeSetName, createErr := cfnClient.CreateChangeSet(ctx, template, params, nil, c.Deployment.StackName, "")
+	changeSetName, createErr := cfnClient.CreateChangeSet(ctx, template, params, c.Deployment.Tags, c.Deployment.StackName, "")
 
 	si.Stop()
 


### PR DESCRIPTION
Adds support for CloudFormation tags in `deployment.yml`:
```yaml
tags:
  key: value
```