### PR TITLE
update registry API to v0.2.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -191,7 +191,7 @@ require (
 	github.com/common-fate/analytics-go v0.1.0
 	github.com/common-fate/clio v1.0.0
 	github.com/common-fate/ddb v0.15.0
-	github.com/common-fate/provider-registry-sdk-go v0.2.1
+	github.com/common-fate/provider-registry-sdk-go v0.2.3
 	github.com/common-fate/testvault v0.1.0
 	github.com/fatih/color v1.13.0
 	github.com/go-chi/cors v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -336,6 +336,8 @@ github.com/common-fate/provider-registry-sdk-go v0.2.0 h1:9rvuwGduqCa4WJi/EO0oef
 github.com/common-fate/provider-registry-sdk-go v0.2.0/go.mod h1:L7Ub4A1IQ9yoQ1r0/lCRyQOvMp7YA7+YJ/hYEKWxzuw=
 github.com/common-fate/provider-registry-sdk-go v0.2.1 h1:ouOsvgQGHj7xwwEnhzgfKNUdYRrQxgYIbb7/qnHUA9M=
 github.com/common-fate/provider-registry-sdk-go v0.2.1/go.mod h1:L7Ub4A1IQ9yoQ1r0/lCRyQOvMp7YA7+YJ/hYEKWxzuw=
+github.com/common-fate/provider-registry-sdk-go v0.2.3 h1:7Tco7By7k97nC+/Vkw2WjCt3mthoZtxeHCibMu05//I=
+github.com/common-fate/provider-registry-sdk-go v0.2.3/go.mod h1:L7Ub4A1IQ9yoQ1r0/lCRyQOvMp7YA7+YJ/hYEKWxzuw=
 github.com/common-fate/testvault v0.1.0 h1:XVhbmcNySGIA203FywYW7wL44Mlcg23UUek3bdg5tzQ=
 github.com/common-fate/testvault v0.1.0/go.mod h1:JJ74LtQZlnjHUj1LuDj2Sz4hEARXf6YOrqzdf3DGFZM=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=


### PR DESCRIPTION
Pull in the changes from https://github.com/common-fate/provider-registry-sdk-go/pull/4