### PR TITLE
CF-764: updated test coverage + idp sync function for filtering

### DIFF
--- a/deploy/infra/lib/constructs/cache-sync.ts
+++ b/deploy/infra/lib/constructs/cache-sync.ts
@@ -32,7 +32,6 @@ export class CacheSync extends Construct {
       environment: {
         COMMONFATE_ACCESS_HANDLER_URL: props.accessHandler.getApiUrl(),
         COMMONFATE_TABLE_NAME: props.dynamoTable.tableName,
-        COMMONFATE_IDENTITY_GROUP_FILTER: props.identityGroupFilter,
       },
       runtime: lambda.Runtime.GO_1_X,
       handler: "cache-sync",

--- a/pkg/identity/identitysync/google.go
+++ b/pkg/identity/identitysync/google.go
@@ -100,7 +100,7 @@ func (c *GoogleSync) ListUsers(ctx context.Context) ([]identity.IDPUser, error) 
 
 }
 
-// userFromOktaUser converts a Google user to the identityprovider interface user type
+// idpUserFromGoogleUser converts a Google user to the identityprovider interface user type
 func (c *GoogleSync) idpUserFromGoogleUser(ctx context.Context, googleUser *admin.User) (identity.IDPUser, error) {
 	u := identity.IDPUser{
 		ID:        googleUser.Id,

--- a/pkg/identity/identitysync/sync.go
+++ b/pkg/identity/identitysync/sync.go
@@ -218,7 +218,7 @@ func (s *IdentitySyncer) setDeploymentInfo(ctx context.Context, log *zap.Sugared
 // contains all the logic for create/update/archive for users and groups
 // It returns a map of users and groups ready to be inserted to the database
 //
-// Expected Behaviour:
+// Expected Behavior:
 // useIdpGroupsAsFilter == true: only users with groups that exist in the IDP will be returned, this is used conditionally with a regex filter that prefilters any groups. Side effects: users with no groups are removed, only filtered groups show in the UI (loss of information; for better or worse)
 //
 // useIdpGroupsAsFilter == false: users with no groups remain, all groups show in the UI. If a user/group is removed from the IDP, it will be archived in the DB
@@ -230,23 +230,7 @@ func processUsersAndGroups(idpType string, idpUsers []identity.IDPUser, idpGroup
 	}
 	idpUserMap := make(map[string]identity.IDPUser)
 	for _, u := range idpUsers {
-
-		// if useIdpGroupsAsFilter {
-		// 	idpUserHasMatchingGroup := false
-		// 	for _, g := range u.Groups {
-		// 		if _, ok := idpGroupMap[g]; ok {
-		// 			idpUserHasMatchingGroup = true
-		// 			break
-		// 		} else {
-		// 			continue
-		// 		}
-		// 	}
-		// 	if idpUserHasMatchingGroup {
-		// 		idpUserMap[u.Email] = u
-		// 	}
-		// } else {
 		idpUserMap[u.Email] = u
-		// }
 	}
 	ddbUserMap := make(map[string]identity.User)
 	for _, u := range internalUsers {
@@ -256,60 +240,33 @@ func processUsersAndGroups(idpType string, idpUsers []identity.IDPUser, idpGroup
 	// This map ensures we have a distinct list of ids
 	internalGroupUsers := make(map[string]map[string]string)
 	for _, g := range internalGroups {
-		// if useIdpGroupsAsFilter {
-		// 	if _, ok := idpGroupMap[g.IdpID]; !ok {
-		// 		continue
-		// 	}
-		// }
 		ddbGroupMap[g.IdpID] = g
 		internalGroupUsers[g.ID] = make(map[string]string)
 	}
 
 	// update/create users
 	for _, u := range idpUserMap {
-		if existing, ok := ddbUserMap[u.Email]; ok { //update
+		//update
+		if existing, ok := ddbUserMap[u.Email]; ok {
 			existing.FirstName = u.FirstName
 			existing.LastName = u.LastName
 			ddbUserMap[u.Email] = existing
-		} else { // create
-
-			if useIdpGroupsAsFilter {
-				userHasMatchingIdpGroup := false
-				for _, g := range u.Groups {
-					if _, ok := idpGroupMap[g]; ok {
-						userHasMatchingIdpGroup = true
-						idpUserMap[u.Email] = u // not covered by tests
-					} else {
-						continue
-					}
-				}
-				if !userHasMatchingIdpGroup {
-					updatedU := u.ToInternalUser()
-					updatedU.Status = types.IdpStatusARCHIVED
-					ddbUserMap[u.Email] = updatedU
-					continue
-				}
-			}
+		} else {
+			// create
 			ddbUserMap[u.Email] = u.ToInternalUser()
 		}
 	}
 	// update/create groups
-	for _, g := range idpGroups {
-		// if useIdpGroupsAsFilter {
-		// 	if _, ok := idpGroupMap[g.ID]; !ok {
-		// 		continue // not covered by tests
-		// 	}
-		// }
-
-		if existing, ok := ddbGroupMap[g.ID]; ok { //update
-			existing.Description = g.Description
-			existing.Name = g.Name
-			existing.Status = types.IdpStatusACTIVE
-			existing.Source = idpType
-			ddbGroupMap[g.ID] = existing
+	for _, idpGroup := range idpGroups {
+		if existingGroup, ok := ddbGroupMap[idpGroup.ID]; ok { //update
+			existingGroup.Description = idpGroup.Description
+			existingGroup.Name = idpGroup.Name
+			existingGroup.Status = types.IdpStatusACTIVE
+			existingGroup.Source = idpType
+			ddbGroupMap[idpGroup.ID] = existingGroup
 		} else { // create
-			newGroup := g.ToInternalGroup(idpType)
-			ddbGroupMap[g.ID] = newGroup
+			newGroup := idpGroup.ToInternalGroup(idpType)
+			ddbGroupMap[idpGroup.ID] = newGroup
 			internalGroupUsers[newGroup.ID] = make(map[string]string)
 		}
 	}
@@ -325,12 +282,6 @@ func processUsersAndGroups(idpType string, idpUsers []identity.IDPUser, idpGroup
 			u.Status = types.IdpStatusACTIVE
 			ddbUserMap[k] = u
 		}
-		// This seems to be needed but it's in the wrong place, should happen at end
-		// // if the user is not in any groups, archive them
-		// if len(u.Groups) == 0 && useIdpGroupsAsFilter {
-		// 	u.Status = types.IdpStatusARCHIVED
-		// 	ddbUserMap[k] = u
-		// }
 	}
 	// archive deleted groups
 	for k, g := range ddbGroupMap {
@@ -367,6 +318,7 @@ func processUsersAndGroups(idpType string, idpUsers []identity.IDPUser, idpGroup
 			// If we are using the IDP groups as a filter, then we only want to add the groups that exist in the IDP
 			if useIdpGroupsAsFilter {
 				if _, ok := idpGroupMap[gid]; !ok {
+					// continue i.e. skip adding this group since it doesn't exist in the IDP
 					continue
 				}
 			}
@@ -385,28 +337,27 @@ func processUsersAndGroups(idpType string, idpUsers []identity.IDPUser, idpGroup
 		internalUser := ddbUserMap[idpUser.Email]
 
 		//make sure we are saving the internal groups that the user is apart of
+		// for every internal user group
 		for _, internalGroupId := range internalUser.Groups {
-			// If we are using the IDP groups as a filter, then we only want to add the groups that exist in the IDP
-			if useIdpGroupsAsFilter {
-				if _, ok := idpGroupMap[internalGroupId]; !ok {
-					continue // not covered by tests
-				}
-			}
+
+			// for each internalGroupId on an internal users groups
+			// get the source of the group from the db
+			// if the group is internal, add it to the list of groups
 
 			source := ddbGroupMap[internalGroupId].Source
+			// if the group is internal, add it to the list of groups
 			if source == identity.INTERNAL {
 				gid := ddbGroupMap[internalGroupId].ID // not covered by tests
 				internalGroupIds[gid] = gid            // not covered by tests
 			}
-
 		}
 
-		keys := make([]string, 0, len(internalGroupIds))
+		groupKeys := make([]string, 0, len(internalGroupIds))
 		for k := range internalGroupIds {
-			keys = append(keys, k)
+			groupKeys = append(groupKeys, k)
 		}
 
-		internalUser.Groups = keys
+		internalUser.Groups = groupKeys
 		// if the user is not in any groups, archive them
 		if len(internalUser.Groups) == 0 && useIdpGroupsAsFilter {
 			internalUser.Status = types.IdpStatusARCHIVED

--- a/pkg/identity/identitysync/sync_test.go
+++ b/pkg/identity/identitysync/sync_test.go
@@ -11,11 +11,6 @@ import (
 )
 
 // The processor contains all the mapping logic for create/update/map for users and groups
-//
-// TODO:
-// This fn has a failed assumption that the ARCHIVED groups & users should be *removed* from the output
-// Side effect: db.Put(...) operation in subsequent calls is not called for the ARCHIVED groups & users,
-// meaning they are not updated (and effectively archived) in the db.
 func TestIdentitySyncProcessor(t *testing.T) {
 
 	type testcase struct {
@@ -595,6 +590,14 @@ func TestIdentitySyncProcessor(t *testing.T) {
 						"user1",
 					},
 				},
+				"group_no_longer_in_idp": {
+					ID:          "group_no_longer_in_idp",
+					IdpID:       "group_no_longer_in_idp",
+					Name:        "everyone",
+					Description: "a description",
+					Status:      types.IdpStatusARCHIVED,
+					Users:       []string{},
+				},
 			},
 			useIdpGroupsAsFilter: true,
 		},
@@ -632,6 +635,8 @@ func TestIdentitySyncProcessor(t *testing.T) {
 					Name:        "everyone",
 					Description: "a description",
 					Status:      types.IdpStatusACTIVE,
+					Source:      identity.INTERNAL,
+					Users:       []string{},
 				},
 				{
 					ID:          "group_no_longer_in_idp",
@@ -639,6 +644,8 @@ func TestIdentitySyncProcessor(t *testing.T) {
 					Name:        "everyone",
 					Description: "a description",
 					Status:      types.IdpStatusACTIVE,
+					Users:       []string{},
+					Source:      identity.INTERNAL,
 				},
 			},
 			wantUserMap: map[string]identity.User{
@@ -658,6 +665,7 @@ func TestIdentitySyncProcessor(t *testing.T) {
 					Description: "a description",
 					Status:      types.IdpStatusACTIVE,
 					Users:       []string{},
+					Source:      identity.INTERNAL,
 				},
 				"group_no_longer_in_idp": {
 					ID:          "group_no_longer_in_idp",
@@ -665,8 +673,11 @@ func TestIdentitySyncProcessor(t *testing.T) {
 					Name:        "everyone",
 					Description: "a description",
 					Status:      types.IdpStatusARCHIVED,
+					Users:       []string{},
+					Source:      identity.INTERNAL,
 				},
 			},
+			withIdpType:          identity.INTERNAL,
 			useIdpGroupsAsFilter: true,
 		},
 	}

--- a/pkg/identity/identitysync/sync_test.go
+++ b/pkg/identity/identitysync/sync_test.go
@@ -11,6 +11,11 @@ import (
 )
 
 // The processor contains all the mapping logic for create/update/map for users and groups
+//
+// TODO:
+// This fn has a failed assumption that the ARCHIVED groups & users should be *removed* from the output
+// Side effect: db.Put(...) operation in subsequent calls is not called for the ARCHIVED groups & users,
+// meaning they are not updated (and effectively archived) in the db.
 func TestIdentitySyncProcessor(t *testing.T) {
 
 	type testcase struct {
@@ -430,6 +435,13 @@ func TestIdentitySyncProcessor(t *testing.T) {
 					Groups:    []string{"admins"},
 					Status:    types.IdpStatusACTIVE,
 				},
+				"alice@mail.com": {
+					ID:        "user3",
+					FirstName: "alice",
+					Email:     "alice@mail.com",
+					Groups:    []string{},
+					Status:    types.IdpStatusARCHIVED,
+				},
 			},
 			wantGroupMap: map[string]identity.Group{
 				"admins": {
@@ -513,6 +525,146 @@ func TestIdentitySyncProcessor(t *testing.T) {
 					Users: []string{
 						"user1",
 					},
+				},
+			},
+			useIdpGroupsAsFilter: true,
+		},
+		{
+			name: "group must be updated to ARCHIVED if NOT present in IDP, but ACTIVE internally",
+			giveIdpUsers: []identity.IDPUser{
+				{
+					ID:        "user1",
+					FirstName: "bob",
+					Email:     "bob@mail.com",
+					Groups: []string{
+						"admins",
+						"group_no_longer_in_idp",
+					},
+				},
+			},
+			giveIdpGroups: []identity.IDPGroup{
+				{
+					ID:          "admins",
+					Name:        "everyone",
+					Description: "a description",
+				},
+			},
+			giveInternalUsers: []identity.User{
+				{
+					ID:        "user1",
+					FirstName: "bob",
+					Email:     "bob@mail.com",
+					Status:    types.IdpStatusACTIVE,
+				},
+			},
+			giveInternalGroups: []identity.Group{
+				{
+					ID:          "admins",
+					IdpID:       "admins",
+					Name:        "everyone",
+					Description: "a description",
+					Status:      types.IdpStatusACTIVE,
+				},
+				{
+					ID:          "group_no_longer_in_idp",
+					IdpID:       "group_no_longer_in_idp",
+					Name:        "everyone",
+					Description: "a description",
+					Status:      types.IdpStatusACTIVE,
+				},
+			},
+			wantUserMap: map[string]identity.User{
+				"bob@mail.com": {
+					ID:        "user1",
+					FirstName: "bob",
+					Email:     "bob@mail.com",
+					Groups: []string{
+						"admins",
+					},
+					Status: types.IdpStatusACTIVE,
+				},
+			},
+			wantGroupMap: map[string]identity.Group{
+				"admins": {
+					ID:          "admins",
+					IdpID:       "admins",
+					Name:        "everyone",
+					Description: "a description",
+					Status:      types.IdpStatusACTIVE,
+					Users: []string{
+						"user1",
+					},
+				},
+			},
+			useIdpGroupsAsFilter: true,
+		},
+		{
+			name: "user must be ARCHIVED if NOT in ACTIVE idp group",
+			giveIdpUsers: []identity.IDPUser{
+				{
+					ID:        "user1",
+					FirstName: "bob",
+					Email:     "bob@mail.com",
+					Groups: []string{
+						"group_no_longer_in_idp",
+					},
+				},
+			},
+			giveIdpGroups: []identity.IDPGroup{
+				{
+					ID:          "admins",
+					Name:        "everyone",
+					Description: "a description",
+				},
+			},
+			giveInternalUsers: []identity.User{
+				{
+					ID:        "user1",
+					FirstName: "bob",
+					Email:     "bob@mail.com",
+					Status:    types.IdpStatusACTIVE,
+				},
+			},
+			giveInternalGroups: []identity.Group{
+				{
+					ID:          "admins",
+					IdpID:       "admins",
+					Name:        "everyone",
+					Description: "a description",
+					Status:      types.IdpStatusACTIVE,
+				},
+				{
+					ID:          "group_no_longer_in_idp",
+					IdpID:       "group_no_longer_in_idp",
+					Name:        "everyone",
+					Description: "a description",
+					Status:      types.IdpStatusACTIVE,
+				},
+			},
+			wantUserMap: map[string]identity.User{
+				"bob@mail.com": {
+					ID:        "user1",
+					FirstName: "bob",
+					Email:     "bob@mail.com",
+					Groups:    []string{},
+					Status:    types.IdpStatusARCHIVED,
+				},
+			},
+			wantGroupMap: map[string]identity.Group{
+				"admins": {
+					ID:          "admins",
+					IdpID:       "admins",
+					Name:        "everyone",
+					Description: "a description",
+					Status:      types.IdpStatusACTIVE,
+					Users:       []string{},
+				},
+				"group_no_longer_in_idp": {
+					ID:          "group_no_longer_in_idp",
+					IdpID:       "group_no_longer_in_idp",
+					Name:        "everyone",
+					Description: "a description",
+					Status:      types.IdpStatusARCHIVED,
 				},
 			},
 			useIdpGroupsAsFilter: true,


### PR DESCRIPTION
## Describe your changes

PR please see linear tickets for comments/handover
https://linear.app/common-fate/issue/CF-764/[qred]-idp-sync-filter-not-working

Fixes a broken assumption wherein `processUsersAndGroups()` was completely removing archived group from the output
Unintended side effect was that `db.Put(...)` operation in subsequent calls is not called for the ARCHIVED groups & users

This PR fixes this assumption effectively archiving new users/groups

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
 

## Testing

<!-- Please describe how the reviewer can test the changes. Also include steps to reproduce the testing environment. -->

1. 

## Checklist before requesting a review

<!-- Please tick off this checklist to ensure you have met all requirements prior to PR -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] Do we need to implement analytics? If so, have you followed up with @ellie-narducci?
- [ ] I have made corresponding changes to the documentation, docs PR has been linked.
- [x] New and existing unit tests pass with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
