### PR TITLE
schema updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -191,7 +191,7 @@ require (
 	github.com/common-fate/analytics-go v0.1.0
 	github.com/common-fate/clio v1.0.0
 	github.com/common-fate/ddb v0.15.0
-	github.com/common-fate/provider-registry-sdk-go v0.2.5
+	github.com/common-fate/provider-registry-sdk-go v0.5.0
 	github.com/common-fate/testvault v0.1.0
 	github.com/fatih/color v1.13.0
 	github.com/go-chi/cors v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -342,6 +342,10 @@ github.com/common-fate/provider-registry-sdk-go v0.2.4 h1:PbTvm3MfviU2K7eP0i+4t7
 github.com/common-fate/provider-registry-sdk-go v0.2.4/go.mod h1:L7Ub4A1IQ9yoQ1r0/lCRyQOvMp7YA7+YJ/hYEKWxzuw=
 github.com/common-fate/provider-registry-sdk-go v0.2.5 h1:PCoCe/tgFUeYfBFTHdDfpy652tcuE4gzpxrjw35ucPc=
 github.com/common-fate/provider-registry-sdk-go v0.2.5/go.mod h1:L7Ub4A1IQ9yoQ1r0/lCRyQOvMp7YA7+YJ/hYEKWxzuw=
+github.com/common-fate/provider-registry-sdk-go v0.4.0 h1:WMSM7frwphQyxxe6D16pGwT5dkkZueimYYSoZhCsxps=
+github.com/common-fate/provider-registry-sdk-go v0.4.0/go.mod h1:L7Ub4A1IQ9yoQ1r0/lCRyQOvMp7YA7+YJ/hYEKWxzuw=
+github.com/common-fate/provider-registry-sdk-go v0.5.0 h1:cE/xFYAxgOuyGLuCEvJWRAjFNJ2/NiUEMjj/6oCebCw=
+github.com/common-fate/provider-registry-sdk-go v0.5.0/go.mod h1:L7Ub4A1IQ9yoQ1r0/lCRyQOvMp7YA7+YJ/hYEKWxzuw=
 github.com/common-fate/testvault v0.1.0 h1:XVhbmcNySGIA203FywYW7wL44Mlcg23UUek3bdg5tzQ=
 github.com/common-fate/testvault v0.1.0/go.mod h1:JJ74LtQZlnjHUj1LuDj2Sz4hEARXf6YOrqzdf3DGFZM=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/pkg/api/provider.go
+++ b/pkg/api/provider.go
@@ -140,18 +140,18 @@ func (a *API) AdminGetProviderArgs(w http.ResponseWriter, r *http.Request, provi
 		schema := ahTypes.ArgSchema{
 			AdditionalProperties: map[string]ahTypes.Argument{},
 		}
-		for k, v := range q.Result.TargetSchema.Schema.AdditionalProperties {
+		for k, v := range q.Result.TargetSchema.Schema.Properties {
 			a := ahTypes.Argument{
 				Id:           k,
 				Description:  v.Description,
-				ResourceName: v.ResourceName,
+				ResourceName: v.Resource,
 				Title:        v.Title,
 				Groups: &ahTypes.Argument_Groups{
 					AdditionalProperties: map[string]ahTypes.Group{},
 				},
 				RuleFormElement: ahTypes.ArgumentRuleFormElementINPUT,
 			}
-			if v.ResourceName != nil {
+			if v.Resource != nil {
 				a.RuleFormElement = ahTypes.ArgumentRuleFormElementMULTISELECT
 			}
 			schema.AdditionalProperties[k] = a

--- a/pkg/api/targetgroup_test.go
+++ b/pkg/api/targetgroup_test.go
@@ -39,7 +39,7 @@ func TestCreateTargetGroup(t *testing.T) {
 			give: `{"id": "test", "targetSchema": "v1.0.1"}`,
 			mockCreate: &target.Group{
 				ID:           "test",
-				TargetSchema: target.GroupTargetSchema{From: "v1.0.1", Schema: providerregistrysdk.TargetMode_Schema{}},
+				TargetSchema: target.GroupTargetSchema{From: "v1.0.1", Schema: providerregistrysdk.TargetKind{}},
 			},
 			wantCode: http.StatusCreated,
 
@@ -112,12 +112,12 @@ func TestListTargetGroup(t *testing.T) {
 			targetgroups: []target.Group{
 				{
 					ID:           "tg1",
-					TargetSchema: target.GroupTargetSchema{From: "test", Schema: providerregistrysdk.TargetMode_Schema{AdditionalProperties: map[string]providerregistrysdk.TargetArgument{}}},
+					TargetSchema: target.GroupTargetSchema{From: "test", Schema: providerregistrysdk.TargetKind{Properties: map[string]providerregistrysdk.TargetArgument{}}},
 					Icon:         "test",
 				},
 				{
 					ID:           "tg2",
-					TargetSchema: target.GroupTargetSchema{From: "test", Schema: providerregistrysdk.TargetMode_Schema{AdditionalProperties: map[string]providerregistrysdk.TargetArgument{}}},
+					TargetSchema: target.GroupTargetSchema{From: "test", Schema: providerregistrysdk.TargetKind{Properties: map[string]providerregistrysdk.TargetArgument{}}},
 					Icon:         "test",
 				},
 			},

--- a/pkg/service/cachesvc/resource_fetcher.go
+++ b/pkg/service/cachesvc/resource_fetcher.go
@@ -71,7 +71,7 @@ func (rf *ResourceFetcher) LoadResources(ctx context.Context, tasks []string) ([
 // Recursively call the provider lambda handler unless there is no further pending tasks.
 // the response Resource is then appended to `rf.resources` for batch DB update later on.
 func (rf *ResourceFetcher) getResources(ctx context.Context, response handlerruntime.LoadResourceResponse) error {
-	if len(response.PendingTasks) == 0 || len(response.Resources) > 0 {
+	if len(response.Tasks) == 0 || len(response.Resources) > 0 {
 
 		rf.resourcesMx.Lock()
 		for _, i := range response.Resources {
@@ -88,7 +88,7 @@ func (rf *ResourceFetcher) getResources(ctx context.Context, response handlerrun
 		rf.resourcesMx.Unlock()
 	}
 
-	for _, task := range response.PendingTasks {
+	for _, task := range response.Tasks {
 		// copy the loop variable
 		tc := task
 		rf.eg.Go(func() error {

--- a/pkg/service/cachesvc/targetgroupcache.go
+++ b/pkg/service/cachesvc/targetgroupcache.go
@@ -85,7 +85,7 @@ func (s *Service) fetchResources(ctx context.Context, tg target.Group) ([]cache.
 	if routeResult.Handler.ProviderDescription == nil {
 		return nil, errors.New("expected ProviderDescription to not be nil")
 	}
-	for k := range routeResult.Handler.ProviderDescription.Schema.Audit.ResourceLoaders.AdditionalProperties {
+	for k := range routeResult.Handler.ProviderDescription.Schema.Resources.Loaders {
 		tasks = append(tasks, k)
 	}
 

--- a/pkg/service/healthchecksvc/healthcheck_test.go
+++ b/pkg/service/healthchecksvc/healthcheck_test.go
@@ -22,9 +22,9 @@ func TestValidateProviderSchema(t *testing.T) {
 		schema2    map[string]providerregistrysdk.TargetArgument
 		valid_want bool
 	}
-	a := map[string]providerregistrysdk.TargetArgument{"1": {Id: "abc", ResourceName: aws.String("abc")}}
-	b := map[string]providerregistrysdk.TargetArgument{"1": {Id: "abc", ResourceName: aws.String("efg")}}
-	c := map[string]providerregistrysdk.TargetArgument{"1": {Id: "abc", ResourceName: nil}}
+	a := map[string]providerregistrysdk.TargetArgument{"1": {Id: "abc", Resource: aws.String("abc")}}
+	b := map[string]providerregistrysdk.TargetArgument{"1": {Id: "abc", Resource: aws.String("efg")}}
+	c := map[string]providerregistrysdk.TargetArgument{"1": {Id: "abc", Resource: nil}}
 	testcases := []testcase{
 		{name: "identical-valid", schema1: a, schema2: a, valid_want: true},
 		{name: "different-invalid", schema1: a, schema2: b, valid_want: false},
@@ -65,9 +65,7 @@ func TestValidateRoute(t *testing.T) {
 			group: target.Group{},
 			providerDescription: &providerregistrysdk.DescribeResponse{
 				Schema: providerregistrysdk.ProviderSchema{
-					Target: providerregistrysdk.TargetSchema{
-						AdditionalProperties: map[string]providerregistrysdk.TargetMode{},
-					},
+					Targets: &providerregistrysdk.TargetSchema{},
 				},
 			},
 			want: test2Route.SetValidity(false).AddDiagnostic(NewDiagKindSchemaNotExist(test2Route)),
@@ -78,10 +76,8 @@ func TestValidateRoute(t *testing.T) {
 			group: target.Group{},
 			providerDescription: &providerregistrysdk.DescribeResponse{
 				Schema: providerregistrysdk.ProviderSchema{
-					Target: providerregistrysdk.TargetSchema{
-						AdditionalProperties: map[string]providerregistrysdk.TargetMode{
-							test2Route.Kind: {},
-						},
+					Targets: &providerregistrysdk.TargetSchema{
+						test2Route.Kind: {},
 					},
 				},
 			},

--- a/pkg/service/rulesvc/create.go
+++ b/pkg/service/rulesvc/create.go
@@ -112,7 +112,7 @@ func (s *Service) ProcessTarget(ctx context.Context, in types.CreateAccessRuleTa
 
 		for argumentID, argument := range in.With.AdditionalProperties {
 			// check if the provided argId is a valid argument id in TargetGroup's schema.
-			arg, ok := q.Result.TargetSchema.Schema.Get(argumentID)
+			arg, ok := q.Result.TargetSchema.Schema.Properties[argumentID]
 			if !ok {
 				return rule.Target{}, apio.NewRequestError(fmt.Errorf("argument '%s' does not match schema for targetgroup '%s'", argumentID, in.ProviderId), http.StatusBadRequest)
 			}
@@ -121,8 +121,8 @@ func (s *Service) ProcessTarget(ctx context.Context, in types.CreateAccessRuleTa
 				return rule.Target{}, apio.NewRequestError(errors.New("argument must have associated value with it"), http.StatusBadRequest)
 			}
 
-			if arg.ResourceName != nil {
-				qGetResourcesForTG := storage.ListCachedTargetGroupResource{TargetGroupID: in.ProviderId, ResourceType: *arg.ResourceName}
+			if arg.Resource != nil {
+				qGetResourcesForTG := storage.ListCachedTargetGroupResource{TargetGroupID: in.ProviderId, ResourceType: *arg.Resource}
 				_, err := s.DB.Query(ctx, &qGetResourcesForTG)
 				if err != nil {
 					return rule.Target{}, err

--- a/pkg/service/rulesvc/request-arguments.go
+++ b/pkg/service/rulesvc/request-arguments.go
@@ -28,9 +28,9 @@ func (s *Service) RequestArguments(ctx context.Context, accessRuleTarget rule.Ta
 		for k, v := range accessRuleTarget.WithSelectable {
 			arg := targetGroupRequestArguments[k]
 			arg.Title = k
-			resource := targetGroup.Result.TargetSchema.Schema.AdditionalProperties[k]
+			resource := targetGroup.Result.TargetSchema.Schema.Properties[k]
 
-			argOptionsQuery := &storage.ListCachedTargetGroupResource{TargetGroupID: accessRuleTarget.TargetGroupID, ResourceType: *resource.ResourceName}
+			argOptionsQuery := &storage.ListCachedTargetGroupResource{TargetGroupID: accessRuleTarget.TargetGroupID, ResourceType: *resource.Resource}
 			_, err := s.DB.Query(ctx, argOptionsQuery)
 			if err != nil && err != ddb.ErrNoItems {
 				return nil, err

--- a/pkg/target/group.go
+++ b/pkg/target/group.go
@@ -24,7 +24,7 @@ type GroupTargetSchema struct {
 	// Reference to the provider and mode from the registry "commonfate/okta@v1.0.0/Group"
 	From string `json:"from" dynamodbav:"from"`
 	// Schema is denomalised and saved here for efficiency
-	Schema providerregistrysdk.TargetMode_Schema `json:"schema" dynamodbav:"schema"`
+	Schema providerregistrysdk.TargetKind `json:"schema" dynamodbav:"schema"`
 }
 
 func (r *Group) DDBKeys() (ddb.Keys, error) {
@@ -43,7 +43,7 @@ func (r *GroupTargetSchema) ToAPI() types.TargetGroupTargetSchema {
 		},
 	}
 
-	for grsI, grs := range r.Schema.AdditionalProperties {
+	for grsI, grs := range r.Schema.Properties {
 		ta := types.TargetArgument{
 			Id:          grs.Id,
 			Description: &grs.Id,
@@ -51,7 +51,7 @@ func (r *GroupTargetSchema) ToAPI() types.TargetGroupTargetSchema {
 		}
 		// if the argument is for a resource that means i should be selected from options
 		// it if is a string argument, resource name is nil meaning it is an input
-		if grs.ResourceName != nil {
+		if grs.Resource != nil {
 			ta.RuleFormElement = types.TargetArgumentRuleFormElementMULTISELECT
 		}
 		resp.Schema.AdditionalProperties[grsI] = ta

--- a/pkg/target/testing.go
+++ b/pkg/target/testing.go
@@ -10,7 +10,7 @@ func TestGroup(opt ...func(*Group)) Group {
 		Icon: "aws-sso",
 		TargetSchema: GroupTargetSchema{
 			From:   "test/test/v1.1.1",
-			Schema: providerregistrysdk.TargetMode_Schema{AdditionalProperties: map[string]providerregistrysdk.TargetArgument{}},
+			Schema: providerregistrysdk.TargetKind{Properties: map[string]providerregistrysdk.TargetArgument{}},
 		},
 	}
 


### PR DESCRIPTION
Updates the schema so that the core types come from this Python library: https://github.com/common-fate/schema. The "official" v1alpha1 Provider schema can be found here: https://schema.commonfate.io/provider/v1alpha1

When cleaning up the schema I've focused on mitigating mixing `camelCase` with `snake_case` (instead aiming to have shorter, single word definitions), and also made things more compatible with JSON Shema. Our Provider schema is now a [metaschema](https://json-schema.org/specification.html#meta-schemas) which means that VSCode and other tools will automatically provide autocomplete and linting for provider schemas.

After these cleanups our schema looks like this:

```json
{
  "$id": "https://registry.commonfate.io/schema/common-fate/example/v1",
  "$schema": "https://schema.commonfate.io/provider/v1alpha1",
  "config": {
    "api_url": {
      "secret": false,
      "type": "string"
    }
  },
  "meta": {
    "framework": "dev"
  },
  "resources": {
    "loaders": {
      "example": {
        "title": "example"
      }
    },
    "types": {
      "MyResource": {
        "type": "string"
      }
    }
  },
  "targets": {
    "Group": {
      "properties": {
        "value": {
          "resource": "MyGroup",
          "type": "string"
        }
      },
      "type": "object"
    }
  }
}
```