### PR TITLE
hotfix: missing deployment config assignment

### DIFF
--- a/pkg/deploy/config.go
+++ b/pkg/deploy/config.go
@@ -479,6 +479,12 @@ func (c *Config) CfnParams() ([]types.Parameter, error) {
 			ParameterValue: &p.CloudfrontWAFACLARN,
 		})
 	}
+	if c.Deployment.Parameters.IdentityGroupFilter != "" {
+		res = append(res, types.Parameter{
+			ParameterKey:   aws.String("IdentityGroupFilter"),
+			ParameterValue: &p.IdentityGroupFilter,
+		})
+	}
 
 	if c.Deployment.Parameters.ExperimentalRemoteConfigURL != "" {
 		res = append(res, types.Parameter{


### PR DESCRIPTION
## Describe your changes

Hi @chrnorm, this should unblock us for the production group filter. I've tested the changes using your prescribed release workflow. 

![image](https://user-images.githubusercontent.com/21688404/223598462-3a352185-9356-417a-961a-c3425a4ec808.png)
![image](https://user-images.githubusercontent.com/21688404/223598459-0de860c5-1e39-4b0e-b15a-aac4a71c2b81.png)

