### PR TITLE
change ABAC role name to 'handler-invoke'

### DIFF
--- a/deploy/infra/lib/helpers/permissions.ts
+++ b/deploy/infra/lib/helpers/permissions.ts
@@ -12,8 +12,7 @@ export const grantAssumeHandlerRole = (_lambda: lambda.Function) => {
       actions: ["sts:AssumeRole"],
       conditions: {
         StringEquals: {
-          "iam:ResourceTag/common-fate-abac-role":
-            "access-provider-invocation-role",
+          "iam:ResourceTag/common-fate-abac-role": "handler-invoke",
         },
       },
     })


### PR DESCRIPTION
(bikeshedding here) main motivation is to remove 'access-provider' as in future the role may be for other kinds of providers
