### PR TITLE
add a diagnostic warning if the handler has an incompatible schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -141,7 +141,7 @@ require (
 )
 
 require (
-	github.com/aws/aws-sdk-go-v2/credentials v1.13.15 // indirect
+	github.com/aws/aws-sdk-go-v2/credentials v1.13.15
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.23 // indirect

--- a/pkg/providerschema/providerschema.go
+++ b/pkg/providerschema/providerschema.go
@@ -1,0 +1,24 @@
+package providerschema
+
+import (
+	"fmt"
+	"strings"
+)
+
+// schemaIsSupported is a check which prevents incompatible providers
+// being registered with Common Fate.
+func IsSupported(schema string) error {
+	supported := []string{
+		"https://schema.commonfate.io/provider/v1alpha1",
+		// add additional schemas here when they are introduced.
+	}
+
+	for _, s := range supported {
+		if schema == s {
+			return nil
+		}
+	}
+
+	// if we get here, we have an unsupported schema
+	return fmt.Errorf("schema '%s' is unsupported by this version of Common Fate (supported schemas: %s)", schema, strings.Join(supported, ", "))
+}

--- a/pkg/service/healthchecksvc/service.go
+++ b/pkg/service/healthchecksvc/service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/common-fate/apikit/logger"
 	"github.com/common-fate/common-fate/pkg/handler"
+	"github.com/common-fate/common-fate/pkg/providerschema"
 	"github.com/common-fate/common-fate/pkg/storage"
 	"github.com/common-fate/common-fate/pkg/target"
 	"github.com/common-fate/common-fate/pkg/types"
@@ -140,6 +141,16 @@ func describe(ctx context.Context, h handler.Handler, runtime Runtime) handler.H
 			Message: diagnostic.Msg,
 		})
 	}
+
+	// warn the user if the handler uses an unsupported schema
+	schemaErr := providerschema.IsSupported(describeRes.Schema.Schema)
+	if schemaErr != nil {
+		h.Diagnostics = append(h.Diagnostics, handler.Diagnostic{
+			Level:   types.LogLevelWARNING,
+			Message: schemaErr.Error(),
+		})
+	}
+
 	h.ProviderDescription = describeRes
 	h.Healthy = describeRes.Healthy
 	return h

--- a/pkg/service/targetsvc/create.go
+++ b/pkg/service/targetsvc/create.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/common-fate/common-fate/pkg/providerschema"
 	"github.com/common-fate/common-fate/pkg/storage"
 	"github.com/common-fate/common-fate/pkg/target"
 	"github.com/pkg/errors"
@@ -85,11 +84,6 @@ func (s *Service) CreateGroup(ctx context.Context, req types.CreateTargetGroupRe
 		return nil, errors.Wrap(fmt.Errorf(response.JSON500.Error), "received 500 error from registry service when fetching provider")
 	default:
 		return nil, fmt.Errorf("unhandled response code received from registry service when querying for a provider status Code: %d Body: %s", response.StatusCode(), string(response.Body))
-	}
-
-	err = providerschema.IsSupported(response.JSON200.Schema.Schema)
-	if err != nil {
-		return nil, err
 	}
 
 	targets := response.JSON200.Schema.Targets

--- a/pkg/service/targetsvc/create.go
+++ b/pkg/service/targetsvc/create.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/common-fate/common-fate/pkg/providerschema"
 	"github.com/common-fate/common-fate/pkg/storage"
 	"github.com/common-fate/common-fate/pkg/target"
 	"github.com/pkg/errors"
@@ -81,10 +82,16 @@ func (s *Service) CreateGroup(ctx context.Context, req types.CreateTargetGroupRe
 	case http.StatusNotFound:
 		return nil, ErrProviderNotFoundInRegistry
 	case http.StatusInternalServerError:
-		return nil, errors.Wrap(fmt.Errorf(response.JSON500.Error), "recieved 500 error from registry service when fetching provider")
+		return nil, errors.Wrap(fmt.Errorf(response.JSON500.Error), "received 500 error from registry service when fetching provider")
 	default:
-		return nil, fmt.Errorf("unhandled response code recieved from registry service when querying for a provider status Code: %d Body: %s", response.StatusCode(), string(response.Body))
+		return nil, fmt.Errorf("unhandled response code received from registry service when querying for a provider status Code: %d Body: %s", response.StatusCode(), string(response.Body))
 	}
+
+	err = providerschema.IsSupported(response.JSON200.Schema.Schema)
+	if err != nil {
+		return nil, err
+	}
+
 	targets := response.JSON200.Schema.Targets
 	if targets == nil {
 		return nil, errors.New("provider does not provide any targets")

--- a/pkg/service/targetsvc/create_test.go
+++ b/pkg/service/targetsvc/create_test.go
@@ -90,25 +90,6 @@ func TestCreateTargetGroup(t *testing.T) {
 			providerLookupErr:      ErrProviderNotFoundInRegistry,
 			providerLookupResponse: &providerregistrysdk.GetProviderResponse{HTTPResponse: &http.Response{StatusCode: 404}},
 		},
-		{
-			name:            "incompatible schema",
-			version:         "v1.0.1",
-			give:            types.CreateTargetGroupRequest{Id: tg_name, TargetSchema: fmt.Sprintf("commonfate/%s@v1.0.1/Kind", tg_name)},
-			wantErr:         true,
-			tgLookupwantErr: ddb.ErrNoItems,
-			groupId:         tg_name,
-			providerLookupResponse: &providerregistrysdk.GetProviderResponse{HTTPResponse: &http.Response{StatusCode: 200}, JSON200: &providerregistrysdk.ProviderDetail{
-				Publisher: "commonfate",
-				Name:      tg_name,
-				Version:   "v1.0.1",
-				Schema: providerregistrysdk.Schema{
-					Schema: "invalid-schema",
-					Targets: &map[string]providerregistrysdk.Target{
-						"Kind": {},
-					},
-				},
-			}},
-		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
a check for forwards compatibility purposes - shows a warning diagnostic if the handler uses an incompatible schema