### PR TITLE
CF-831 Make slack notification less noisy

### DIFF
--- a/pkg/notifiers/slack/handle_grant.go
+++ b/pkg/notifiers/slack/handle_grant.go
@@ -53,9 +53,6 @@ func (n *SlackNotifier) HandleGrantEvent(ctx context.Context, log *zap.SugaredLo
 			},
 		}
 		fallback = fmt.Sprintf("Your access to %s is now active.", rq.Result.Name)
-	case gevent.GrantExpiredType:
-		msg = fmt.Sprintf("Your access to *%s* has now expired. If you still need access you can send another request using Common Fate.", rq.Result.Name)
-		fallback = fmt.Sprintf("Your access to %s has now expired.", rq.Result.Name)
 	case gevent.GrantFailedType:
 		msg = fmt.Sprintf("We've had an issue trying to provision or clean up your access to *%s*. We'll keep trying, but if you urgently need access to the role please contact your cloud administrator.", rq.Result.Name)
 		fallback = fmt.Sprintf("We've had an issue with your access to %s", rq.Result.Name)


### PR DESCRIPTION
## Describe your changes
Remove slack notifications for events that doesn't require any secondary actions like "grant expiring" or "requests which were automatically approved"

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


