### PR TITLE
CF-998: paginate access rule page

### DIFF
--- a/pkg/api/accessrule.go
+++ b/pkg/api/accessrule.go
@@ -45,6 +45,7 @@ func (a *API) AdminListAccessRules(w http.ResponseWriter, r *http.Request, param
 
 	var err error
 	var rules []rule.AccessRule
+	var qr *ddb.QueryResult
 
 	queryOpts := []func(*ddb.QueryOpts){ddb.Limit(50)}
 	if params.NextToken != nil {
@@ -53,7 +54,7 @@ func (a *API) AdminListAccessRules(w http.ResponseWriter, r *http.Request, param
 
 	if params.Status != nil {
 		q := storage.ListAccessRulesForStatus{Status: rule.Status(*params.Status)}
-		_, err = a.DB.Query(ctx, &q, queryOpts...)
+		qr, err = a.DB.Query(ctx, &q, queryOpts...)
 		rules = q.Result
 	} else {
 		q := storage.ListCurrentAccessRules{}
@@ -68,6 +69,7 @@ func (a *API) AdminListAccessRules(w http.ResponseWriter, r *http.Request, param
 
 	res := types.ListAccessRulesDetailResponse{
 		AccessRules: make([]types.AccessRuleDetail, len(rules)),
+		Next:        &qr.NextPage,
 	}
 	for i, r := range rules {
 		res.AccessRules[i] = r.ToAPIDetail()


### PR DESCRIPTION
### What changed?
Added pagination to access rule GET route 

### Why?
See linear ticket https://linear.app/common-fate/issue/CF-998/pagination-not-working-in-admin-ui-access-rules-view-only-first-50

### How did you test it?
See notion doc https://www.notion.so/commonfate/Pagination-Access-Rule-Bug-fa967f3d162d465281f5921523b5a041?pvs=4

### Potential risks
n/a

