### PR TITLE
fix check if user has access to rule when grouping + test

### DIFF
--- a/pkg/service/preflightsvc/service_test.go
+++ b/pkg/service/preflightsvc/service_test.go
@@ -94,7 +94,12 @@ func TestGroupTargets(t *testing.T) {
 		{
 			name:    "multiple targets with diff access rules creates multiple groups",
 			targets: []cache.Target{target1, target2},
-			user:    identity.User{ID: "usr_123"},
+			user: identity.User{
+				ID: "usr_123",
+				Groups: []string{
+					"string",
+				},
+			},
 			AccessGroups: []access.PreflightAccessGroup{
 				{
 					Targets: []access.PreflightAccessGroupTarget{{Target: target1, TargetGroupID: "aws"}},
@@ -141,20 +146,17 @@ func TestGroupTargets(t *testing.T) {
 					TimeConstraints: types.AccessRuleTimeConstraints{MaxDurationSeconds: 3600},
 				},
 			},
-			mockGetGroups: []identity.Group{
-				{
-					Users: []string{"usr_123"},
-				},
-				{
-					Users: []string{"usr_123"},
-				},
-			},
 		},
 		{
 			//two access rules, one requires approval and one without. User has access to the one with requires approval. should return correct grouping
 			name:    "user with access to one of two rules gets the correct rule",
 			targets: []cache.Target{target1},
-			user:    identity.User{ID: "usr_123"},
+			user: identity.User{
+				ID: "usr_123",
+				Groups: []string{
+					"reqApproval",
+				},
+			},
 
 			AccessGroups: []access.PreflightAccessGroup{
 				{
@@ -192,14 +194,7 @@ func TestGroupTargets(t *testing.T) {
 					TimeConstraints: types.AccessRuleTimeConstraints{MaxDurationSeconds: 3600},
 				},
 			},
-			mockGetGroups: []identity.Group{
-				{
-					Users: []string{"usr_123"},
-				},
-				{
-					Users: []string{},
-				},
-			},
+
 			wantErr: false,
 		},
 	}
@@ -219,11 +214,11 @@ func TestGroupTargets(t *testing.T) {
 				)
 			}
 
-			for i := range tt.mockGetGroups {
-				db.MockQueries(
-					&storage.GetGroup{Result: &tt.mockGetGroups[i]},
-				)
-			}
+			// for i := range tt.mockGetGroups {
+			// 	db.MockQueries(
+			// 		&storage.GetGroup{Result: &tt.mockGetGroups[i]},
+			// 	)
+			// }
 
 			s := &Service{
 				DB:    db,

--- a/pkg/service/preflightsvc/service_test.go
+++ b/pkg/service/preflightsvc/service_test.go
@@ -86,13 +86,15 @@ func TestGroupTargets(t *testing.T) {
 		targets            []cache.Target
 		AccessGroups       []access.PreflightAccessGroup
 		wantErr            bool
-		mockGetAccessRule1 rule.AccessRule
-		mockGetAccessRule2 rule.AccessRule
+		user               identity.User
+		mockGetAccessRules []rule.AccessRule
+		mockGetGroups      []identity.Group
 	}{
 
 		{
 			name:    "multiple targets with diff access rules creates multiple groups",
 			targets: []cache.Target{target1, target2},
+			user:    identity.User{ID: "usr_123"},
 			AccessGroups: []access.PreflightAccessGroup{
 				{
 					Targets: []access.PreflightAccessGroupTarget{{Target: target1, TargetGroupID: "aws"}},
@@ -111,29 +113,92 @@ func TestGroupTargets(t *testing.T) {
 					RequiresApproval: true,
 				},
 			},
-			mockGetAccessRule1: rule.AccessRule{
-				ID:          "rule1",
-				Description: "string",
-				Name:        "string",
-				Groups:      []string{"string"},
 
-				Approval: rule.Approval{
-					Groups: []string{"a"},
-					Users:  []string{"b"},
+			wantErr: false,
+			mockGetAccessRules: []rule.AccessRule{
+				{
+					ID:          "rule1",
+					Description: "string",
+					Name:        "string",
+					Groups:      []string{"string"},
+
+					Approval: rule.Approval{
+						Groups: []string{"a"},
+						Users:  []string{"b"},
+					},
+					TimeConstraints: types.AccessRuleTimeConstraints{MaxDurationSeconds: 3600},
 				},
-				TimeConstraints: types.AccessRuleTimeConstraints{MaxDurationSeconds: 3600},
+				{
+					ID:          "rule2",
+					Description: "string",
+					Name:        "string",
+					Groups:      []string{"string"},
+
+					Approval: rule.Approval{
+						Groups: []string{"a"},
+						Users:  []string{"b"},
+					},
+					TimeConstraints: types.AccessRuleTimeConstraints{MaxDurationSeconds: 3600},
+				},
 			},
-			mockGetAccessRule2: rule.AccessRule{
-				ID:          "rule2",
-				Description: "string",
-				Name:        "string",
-				Groups:      []string{"string"},
-
-				Approval: rule.Approval{
-					Groups: []string{"a"},
-					Users:  []string{"b"},
+			mockGetGroups: []identity.Group{
+				{
+					Users: []string{"usr_123"},
 				},
-				TimeConstraints: types.AccessRuleTimeConstraints{MaxDurationSeconds: 3600},
+				{
+					Users: []string{"usr_123"},
+				},
+			},
+		},
+		{
+			//two access rules, one requires approval and one without. User has access to the one with requires approval. should return correct grouping
+			name:    "user with access to one of two rules gets the correct rule",
+			targets: []cache.Target{target1},
+			user:    identity.User{ID: "usr_123"},
+
+			AccessGroups: []access.PreflightAccessGroup{
+				{
+					Targets: []access.PreflightAccessGroupTarget{{Target: target1, TargetGroupID: "aws"}},
+					TimeConstraints: types.AccessRuleTimeConstraints{
+						MaxDurationSeconds: 3600,
+					},
+					AccessRule:       "rule1",
+					RequiresApproval: true,
+				},
+			},
+			mockGetAccessRules: []rule.AccessRule{
+				{
+					ID:          "rule1",
+					Description: "string",
+					Name:        "string",
+					Groups:      []string{"reqApproval"},
+
+					Approval: rule.Approval{
+						Groups: []string{},
+						Users:  []string{"usr_123"},
+					},
+					TimeConstraints: types.AccessRuleTimeConstraints{MaxDurationSeconds: 3600},
+				},
+				{
+					ID:          "rule2",
+					Description: "string",
+					Name:        "string",
+					Groups:      []string{"noApprovalNeeded"},
+
+					Approval: rule.Approval{
+						Groups: []string{},
+						Users:  []string{},
+					},
+					TimeConstraints: types.AccessRuleTimeConstraints{MaxDurationSeconds: 3600},
+				},
+			},
+			mockGetGroups: []identity.Group{
+				{
+					Users: []string{"usr_123"},
+				},
+				{
+					Users: []string{},
+				},
 			},
 			wantErr: false,
 		},
@@ -143,17 +208,29 @@ func TestGroupTargets(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			db := ddbmock.New(t)
 
-			db.MockQueries(
-				&storage.GetAccessRule{Result: &tt.mockGetAccessRule1},
-				&storage.GetAccessRule{Result: &tt.mockGetAccessRule2},
-			)
+			// db.MockQueries(
+			// 	&storage.GetAccessRule{Result: &tt.mockGetAccessRules[1]},
+			// 	&storage.GetAccessRule{Result: &tt.mockGetAccessRules[0]},
+			// )
+
+			for i, _ := range tt.mockGetAccessRules {
+				db.MockQueries(
+					&storage.GetAccessRule{Result: &tt.mockGetAccessRules[i]},
+				)
+			}
+
+			for i, _ := range tt.mockGetGroups {
+				db.MockQueries(
+					&storage.GetGroup{Result: &tt.mockGetGroups[i]},
+				)
+			}
 
 			s := &Service{
 				DB:    db,
 				Clock: clk,
 			}
 
-			got, _ := s.GroupTargets(context.Background(), tt.targets)
+			got, _ := s.GroupTargets(context.Background(), tt.targets, tt.user)
 
 			//override ids
 			for i := range tt.AccessGroups {

--- a/pkg/service/preflightsvc/service_test.go
+++ b/pkg/service/preflightsvc/service_test.go
@@ -213,13 +213,13 @@ func TestGroupTargets(t *testing.T) {
 			// 	&storage.GetAccessRule{Result: &tt.mockGetAccessRules[0]},
 			// )
 
-			for i, _ := range tt.mockGetAccessRules {
+			for i := range tt.mockGetAccessRules {
 				db.MockQueries(
 					&storage.GetAccessRule{Result: &tt.mockGetAccessRules[i]},
 				)
 			}
 
-			for i, _ := range tt.mockGetGroups {
+			for i := range tt.mockGetGroups {
 				db.MockQueries(
 					&storage.GetGroup{Result: &tt.mockGetGroups[i]},
 				)


### PR DESCRIPTION
### What changed?
 - Fixed bug where users were not checked if they had access to the rule when grouping targets.

### Why?


### How did you test it?


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs
