### PR TITLE
Update analytics event

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -146,7 +146,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.3
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.17.10
 	github.com/briandowns/spinner v1.23.0
-	github.com/common-fate/analytics-go v0.2.1-0.20230517052548-6d828c441564
+	github.com/common-fate/analytics-go v0.2.1-0.20230518033720-a7a07a450325
 	github.com/common-fate/clio v1.1.0
 	github.com/common-fate/ddb v0.15.1-0.20230424033643-2558c36a3a5e
 	github.com/common-fate/iso8601 v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -146,7 +146,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.3
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.17.10
 	github.com/briandowns/spinner v1.23.0
-	github.com/common-fate/analytics-go v0.2.0
+	github.com/common-fate/analytics-go v0.2.1-0.20230517052548-6d828c441564
 	github.com/common-fate/clio v1.1.0
 	github.com/common-fate/ddb v0.15.1-0.20230424033643-2558c36a3a5e
 	github.com/common-fate/iso8601 v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -245,6 +245,12 @@ github.com/common-fate/analytics-go v0.2.0 h1:XRVwgn8Hti9hPUsacRuUirD9trolDYVopA
 github.com/common-fate/analytics-go v0.2.0/go.mod h1:RmsNL2tYC00c7/pOzgHQYrTMRlY6tp201VFZbAqFCTE=
 github.com/common-fate/analytics-go v0.2.1-0.20230517052548-6d828c441564 h1:WkzVKWLzy5fDShpmkVrHysGz5hzcY1HH+nboT764ep4=
 github.com/common-fate/analytics-go v0.2.1-0.20230517052548-6d828c441564/go.mod h1:RmsNL2tYC00c7/pOzgHQYrTMRlY6tp201VFZbAqFCTE=
+github.com/common-fate/analytics-go v0.2.1-0.20230518030348-71171fa05c38 h1:Rq+2DwP5exMWcZzmke9OQkpR8QQK49/mAUs/pDtFfuo=
+github.com/common-fate/analytics-go v0.2.1-0.20230518030348-71171fa05c38/go.mod h1:RmsNL2tYC00c7/pOzgHQYrTMRlY6tp201VFZbAqFCTE=
+github.com/common-fate/analytics-go v0.2.1-0.20230518032535-55ddc67e9717 h1:BKZSW7/DGHivcYdf3355k2+65RYAocrmE2kxo4/0loU=
+github.com/common-fate/analytics-go v0.2.1-0.20230518032535-55ddc67e9717/go.mod h1:RmsNL2tYC00c7/pOzgHQYrTMRlY6tp201VFZbAqFCTE=
+github.com/common-fate/analytics-go v0.2.1-0.20230518033720-a7a07a450325 h1:BSpuj5lcLwb317UZIkN1dxYTyCBxoCeOsKfY3ztE2Tc=
+github.com/common-fate/analytics-go v0.2.1-0.20230518033720-a7a07a450325/go.mod h1:RmsNL2tYC00c7/pOzgHQYrTMRlY6tp201VFZbAqFCTE=
 github.com/common-fate/apikit v0.2.1-0.20220526131641-1d860b34f6ed h1:75bNrGY5m/CLnxt5IajGf424YiM2WO+5GRgTPvFcLVo=
 github.com/common-fate/apikit v0.2.1-0.20220526131641-1d860b34f6ed/go.mod h1:5WXBU3NBnQ6ZuqQyazwL5Ou6yT7UpC8c3yK8F9mGh9k=
 github.com/common-fate/clio v1.1.0 h1:M5fyMuYHjB+qODYbl0IGT28SBiokxsIlxluUVnD8cOQ=

--- a/go.sum
+++ b/go.sum
@@ -243,6 +243,8 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/common-fate/analytics-go v0.2.0 h1:XRVwgn8Hti9hPUsacRuUirD9trolDYVopARJGyTqOHI=
 github.com/common-fate/analytics-go v0.2.0/go.mod h1:RmsNL2tYC00c7/pOzgHQYrTMRlY6tp201VFZbAqFCTE=
+github.com/common-fate/analytics-go v0.2.1-0.20230517052548-6d828c441564 h1:WkzVKWLzy5fDShpmkVrHysGz5hzcY1HH+nboT764ep4=
+github.com/common-fate/analytics-go v0.2.1-0.20230517052548-6d828c441564/go.mod h1:RmsNL2tYC00c7/pOzgHQYrTMRlY6tp201VFZbAqFCTE=
 github.com/common-fate/apikit v0.2.1-0.20220526131641-1d860b34f6ed h1:75bNrGY5m/CLnxt5IajGf424YiM2WO+5GRgTPvFcLVo=
 github.com/common-fate/apikit v0.2.1-0.20220526131641-1d860b34f6ed/go.mod h1:5WXBU3NBnQ6ZuqQyazwL5Ou6yT7UpC8c3yK8F9mGh9k=
 github.com/common-fate/clio v1.1.0 h1:M5fyMuYHjB+qODYbl0IGT28SBiokxsIlxluUVnD8cOQ=

--- a/pkg/access/request.go
+++ b/pkg/access/request.go
@@ -78,6 +78,11 @@ type Purpose struct {
 	Reason *string `json:"reason" dynamodbav:"reason"`
 }
 
+// return true if reason field is not nil
+func (p Purpose) ToAnalytics() bool {
+	return p.Reason != nil
+}
+
 func (p Purpose) ToAPI() types.RequestPurpose {
 	return types.RequestPurpose{
 		Reason: p.Reason,

--- a/pkg/service/accesssvc/create.go
+++ b/pkg/service/accesssvc/create.go
@@ -181,13 +181,11 @@ func (s *Service) CreateRequest(ctx context.Context, user identity.User, createR
 
 	// analytics event
 	analytics.FromContext(ctx).Track(&analytics.RequestCreated{
-		RequestedBy: request.RequestedBy.ID,
-		// RequestID: request.ID,
-		RuleID:            "",
-		NumOfTargets:      request.GroupTargetCount,
-		NumOfAccessGroups: len(out.Groups),
+		RequestedBy:       request.RequestedBy.ID,
+		RequestID:         request.ID,
+		TargetsCount:      request.GroupTargetCount,
+		AccessGroupsCount: len(out.Groups),
 		HasReason:         request.Purpose.ToAnalytics(),
-		// RequiresApproval:  in.Rule.Approval.IsRequired(),
 	})
 
 	return &out, nil

--- a/pkg/service/accesssvc/create.go
+++ b/pkg/service/accesssvc/create.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/common-fate/analytics-go"
 	"github.com/common-fate/common-fate/pkg/access"
 	"github.com/common-fate/common-fate/pkg/gevent"
 	"github.com/common-fate/common-fate/pkg/identity"
@@ -177,6 +178,17 @@ func (s *Service) CreateRequest(ctx context.Context, user identity.User, createR
 	if err != nil {
 		return nil, err
 	}
+
+	// analytics event
+	analytics.FromContext(ctx).Track(&analytics.RequestCreated{
+		RequestedBy: request.RequestedBy.ID,
+		// RequestID: request.ID,
+		RuleID:            "",
+		NumOfTargets:      request.GroupTargetCount,
+		NumOfAccessGroups: len(out.Groups),
+		HasReason:         request.Purpose.ToAnalytics(),
+		// RequiresApproval:  in.Rule.Approval.IsRequired(),
+	})
 
 	return &out, nil
 

--- a/pkg/service/accesssvc/review.go
+++ b/pkg/service/accesssvc/review.go
@@ -3,6 +3,7 @@ package accesssvc
 import (
 	"context"
 
+	"github.com/common-fate/analytics-go"
 	"github.com/common-fate/common-fate/pkg/access"
 	"github.com/common-fate/common-fate/pkg/gevent"
 	"github.com/common-fate/common-fate/pkg/identity"
@@ -63,6 +64,23 @@ func (s *Service) Review(ctx context.Context, user identity.User, isAdmin bool, 
 	if overlaps {
 		return ErrGroupCannotBeApprovedBecauseItWillOverlapExistingGrants
 	}
+
+	// analytics event for request review
+	// analytics event
+	analytics.FromContext(ctx).Track(&analytics.RequestReviewed{
+		RequestedBy: group.Group.RequestedBy.ID,
+		ReviewedBy:  user.ID,
+		// PendingDurationSeconds: s.Clock.Since(request.CreatedAt).Seconds(),
+		// Review:                 string(r.Decision),
+		// OverrideTiming:         ot,
+		// PDKProvider:            opts.AccessRule.Target.IsForTargetGroup(),
+		// Provider:               opts.AccessRule.Target.TargetGroupFrom.ToAnalytics(),
+		// ReviewerIsAdmin:        opts.ReviewerIsAdmin,
+		// BuiltInProvider:        opts.AccessRule.Target.BuiltInProviderType,
+		// RuleID:                 request.Rule,
+		// Timing:                 request.RequestedTiming.ToAnalytics(),
+		// HasReason:              request.HasReason(),
+	})
 
 	// dispatch the reviewed event to be processed async
 	return s.EventPutter.Put(ctx, gevent.AccessGroupReviewed{

--- a/pkg/service/accesssvc/review.go
+++ b/pkg/service/accesssvc/review.go
@@ -65,21 +65,23 @@ func (s *Service) Review(ctx context.Context, user identity.User, isAdmin bool, 
 		return ErrGroupCannotBeApprovedBecauseItWillOverlapExistingGrants
 	}
 
-	// analytics event for request review
 	// analytics event
+	hasReason := group.Group.RequestPurposeReason != ""
 	analytics.FromContext(ctx).Track(&analytics.RequestReviewed{
-		RequestedBy: group.Group.RequestedBy.ID,
-		ReviewedBy:  user.ID,
-		// PendingDurationSeconds: s.Clock.Since(request.CreatedAt).Seconds(),
-		// Review:                 string(r.Decision),
-		// OverrideTiming:         ot,
-		// PDKProvider:            opts.AccessRule.Target.IsForTargetGroup(),
-		// Provider:               opts.AccessRule.Target.TargetGroupFrom.ToAnalytics(),
-		// ReviewerIsAdmin:        opts.ReviewerIsAdmin,
-		// BuiltInProvider:        opts.AccessRule.Target.BuiltInProviderType,
-		// RuleID:                 request.Rule,
-		// Timing:                 request.RequestedTiming.ToAnalytics(),
-		// HasReason:              request.HasReason(),
+		RequestedBy:   group.Group.RequestedBy.ID,
+		RequestID:     requestID,
+		ReviewedBy:    user.ID,
+		AccessGroupID: group.Group.ID,
+		TargetsCount:  len(group.Targets),
+		Timing:        group.Group.RequestedTiming.ToAnalytics(),
+		OverrideTiming: &analytics.Timing{
+			Mode:            group.Group.OverrideTiming.ToAnalytics().Mode,
+			DurationSeconds: group.Group.OverrideTiming.ToAnalytics().DurationSeconds,
+		},
+		HasReason:              hasReason,
+		PendingDurationSeconds: float64(s.Clock.Since(*group.Group.RequestedTiming.StartTime).Seconds()),
+		Review:                 string(in.Decision),
+		ReviewerIsAdmin:        isAdmin,
 	})
 
 	// dispatch the reviewed event to be processed async

--- a/pkg/service/accesssvc/revoke.go
+++ b/pkg/service/accesssvc/revoke.go
@@ -63,12 +63,13 @@ func (s *Service) RevokeRequest(ctx context.Context, in access.RequestWithGroups
 	}
 	user := auth.UserFromContext(ctx)
 
+	// analytics event
 	analytics.FromContext(ctx).Track(&analytics.RequestRevoked{
-		RequestedBy: in.Request.RequestedBy.ID,
-		// RevokedBy:   u.ID,
-		// RuleID:    req.Rule,
-		// Timing:    req.RequestedTiming.ToAnalytics(),
-		// HasReason: req.HasReason(),
+		RequestedBy:      in.Request.RequestedBy.ID,
+		RevokedBy:        user.ID,
+		RequestID:        in.Request.ID,
+		AccessGroupCount: len(in.Groups),
+		HasReason:        in.Request.Purpose.ToAnalytics(),
 	})
 
 	//emit request group revoke event

--- a/pkg/service/accesssvc/revoke.go
+++ b/pkg/service/accesssvc/revoke.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/common-fate/analytics-go"
 	"github.com/common-fate/common-fate/pkg/access"
 	"github.com/common-fate/common-fate/pkg/auth"
 	"github.com/common-fate/common-fate/pkg/gevent"
@@ -61,6 +62,15 @@ func (s *Service) RevokeRequest(ctx context.Context, in access.RequestWithGroups
 		return nil, err
 	}
 	user := auth.UserFromContext(ctx)
+
+	analytics.FromContext(ctx).Track(&analytics.RequestRevoked{
+		RequestedBy: in.Request.RequestedBy.ID,
+		// RevokedBy:   u.ID,
+		// RuleID:    req.Rule,
+		// Timing:    req.RequestedTiming.ToAnalytics(),
+		// HasReason: req.HasReason(),
+	})
+
 	//emit request group revoke event
 	err = s.EventPutter.Put(ctx, gevent.RequestRevokeInitiated{
 		Request: in,

--- a/pkg/service/rulesvc/create.go
+++ b/pkg/service/rulesvc/create.go
@@ -132,7 +132,7 @@ func (s *Service) CreateAccessRule(ctx context.Context, userID string, in types.
 		return nil, err
 	}
 
-	// analytics event
+	// analytics event Create Access Rule
 	analytics.FromContext(ctx).Track(&analytics.RuleCreated{
 		CreatedBy: userID,
 		RuleID:    rul.ID,

--- a/pkg/service/rulesvc/delete.go
+++ b/pkg/service/rulesvc/delete.go
@@ -3,6 +3,7 @@ package rulesvc
 import (
 	"context"
 
+	"github.com/common-fate/analytics-go"
 	"github.com/common-fate/common-fate/pkg/storage"
 	"github.com/common-fate/ddb"
 )
@@ -20,5 +21,11 @@ func (s *Service) DeleteRule(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
+
+	// analytics event
+	analytics.FromContext(ctx).Track(&analytics.RuleArchived{
+		// ArchivedBy: userId,
+		// RuleID:     in.ID,
+	})
 	return s.Cache.RefreshCachedTargets(ctx)
 }

--- a/pkg/service/rulesvc/delete.go
+++ b/pkg/service/rulesvc/delete.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/common-fate/analytics-go"
+	"github.com/common-fate/common-fate/pkg/auth"
 	"github.com/common-fate/common-fate/pkg/storage"
 	"github.com/common-fate/ddb"
 )
@@ -22,10 +23,12 @@ func (s *Service) DeleteRule(ctx context.Context, id string) error {
 		return err
 	}
 
+	user := auth.UserFromContext(ctx)
+
 	// analytics event
 	analytics.FromContext(ctx).Track(&analytics.RuleArchived{
-		// ArchivedBy: userId,
-		// RuleID:     in.ID,
+		ArchivedBy: user.ID,
+		RuleID:     id,
 	})
 	return s.Cache.RefreshCachedTargets(ctx)
 }

--- a/pkg/service/rulesvc/update.go
+++ b/pkg/service/rulesvc/update.go
@@ -92,7 +92,7 @@ func (s *Service) UpdateRule(ctx context.Context, in *UpdateOpts) (*rule.AccessR
 		return nil, err
 	}
 
-	// analytics event
+	// analytics event Update access rule
 	analytics.FromContext(ctx).Track(&analytics.RuleUpdated{
 		UpdatedBy: in.UpdaterID,
 		RuleID:    in.Rule.ID,

--- a/pkg/service/rulesvc/update.go
+++ b/pkg/service/rulesvc/update.go
@@ -92,14 +92,26 @@ func (s *Service) UpdateRule(ctx context.Context, in *UpdateOpts) (*rule.AccessR
 		return nil, err
 	}
 
+	hasFilterExpression := false
+	selectedTargets := []string{}
+	for _, target := range in.UpdateRequest.Targets {
+		selectedTargets = append(selectedTargets, target.TargetGroupId)
+		if len(target.FieldFilterExpessions) > 0 {
+			hasFilterExpression = true
+		}
+	}
+
 	// analytics event Update access rule
 	analytics.FromContext(ctx).Track(&analytics.RuleUpdated{
-		UpdatedBy: in.UpdaterID,
-		RuleID:    in.Rule.ID,
-		// Provider:           in.Rule.Target.TargetGroupFrom.ToAnalytics(),
-		MaxDurationSeconds: in.Rule.TimeConstraints.MaxDurationSeconds,
-		RequiresApproval:   in.Rule.Approval.IsRequired(),
+		UpdatedBy:           in.UpdaterID,
+		RuleID:              in.Rule.ID,
+		TargetsCount:        len(in.UpdateRequest.Targets),
+		HasFilterExpression: hasFilterExpression,
+		Targets:             selectedTargets,
+		MaxDurationSeconds:  in.Rule.TimeConstraints.MaxDurationSeconds,
+		RequiresApproval:    in.Rule.Approval.IsRequired(),
 	})
+
 	err = s.Cache.RefreshCachedTargets(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### What changed?
Updated the analytics event to capture information as per changes in v1

### Dependent PR 
https://github.com/common-fate/analytics-go/pull/2

### Why?
Previous analytics events were not longer supported. 

### How did you test it?


### Potential risks
1. Probably won't be able to group v0 and v1 events as new events have some new fields and some fields missing. 

### Is patch release candidate?


### Link to relevant docs PRs
