### PR TITLE
fix incorrect config value used for string option for metadata

### DIFF
--- a/cmd/gdeploy/commands/identity/sso/enable.go
+++ b/cmd/gdeploy/commands/identity/sso/enable.go
@@ -143,7 +143,7 @@ func updateOrAddSSO(c *cli.Context, idpType string) error {
 			}
 		case fromString:
 			p5 := &survey.Input{Message: "Metadata XML String"}
-			err = survey.AskOne(p5, &dc.Deployment.Parameters.SamlSSOMetadataURL)
+			err = survey.AskOne(p5, &dc.Deployment.Parameters.SamlSSOMetadata)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### What changed?
use correct config parameter for sso saml metadata

### Why?


### How did you test it?


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs
