### PR TITLE
increase CLI access token validity

### DIFF
--- a/deploy/infra/lib/constructs/app-user-pool.ts
+++ b/deploy/infra/lib/constructs/app-user-pool.ts
@@ -181,6 +181,7 @@ export class WebUserPool extends Construct {
     // create an app client for the CLI
     this._cliAppClient = this._userPool.addClient("CLI", {
       supportedIdentityProviders: [UserPoolClientIdentityProvider.custom(idp)],
+      accessTokenValidity: cdk.Duration.hours(24),
       oAuth: {
         flows: {
           authorizationCodeGrant: true,


### PR DESCRIPTION
### What changed?
Increase CLI access token validity to 24hrs

### Why?
Granted CLI has an issue where the token refresh flow does not work - this is a temporary workaround to mitigate UX issues.

### How did you test it?
~~Requires UAT deployment test~~ tested in a preview deployment and CLI login flow still works.

### Potential risks


### Is patch release candidate?
Yes

### Link to relevant docs PRs
