### PR TITLE
Fixed UI error that did not display time in months

### DIFF
--- a/web/src/utils/durationString.tsx
+++ b/web/src/utils/durationString.tsx
@@ -23,7 +23,7 @@ export const durationStringHoursMinutes = (d?: Duration): string => {
       return "few seconds";
     }
     return formatDuration(d, {
-      format: ["days", "hours", "minutes"],
+      format: ["years", "months", "weeks", "days", "hours", "minutes"],
     });
   } else return "";
 };


### PR DESCRIPTION
### What changed?
If access time is requested in months, the "Active for the next" section shows the active time accurately

### Why?
Previously the "Active for the next" section did not display time in months 

### How did you test it?
Ran the changes locally
<img width="686" alt="Screen Shot 2023-07-08 at 4 34 47 PM" src="https://github.com/common-fate/common-fate/assets/32020525/cf0892e1-b1ba-40c9-9450-c6c4b41edc2a">

### Potential risks


### Is patch release candidate?
No

### Link to relevant docs PRs
[Linear](https://linear.app/common-fate/issue/CF-1569/bug-found-when-creating-access-rules-with-max-duration-of-26-weeks)
