### PR TITLE
Append IdentityGroupFilter to CF parameter list

### DIFF
--- a/pkg/deploy/config.go
+++ b/pkg/deploy/config.go
@@ -455,6 +455,13 @@ func (c *Config) CfnParams() ([]types.Parameter, error) {
 		})
 	}
 
+	if p.IdentityGroupFilter != "" {
+		res = append(res, types.Parameter{
+			ParameterKey:   aws.String("IdentityGroupFilter"),
+			ParameterValue: &p.IdentityGroupFilter,
+		})
+	}
+
 	if c.Deployment.Parameters.FrontendCertificateARN != "" {
 		res = append(res, types.Parameter{
 			ParameterKey:   aws.String("FrontendCertificateARN"),

--- a/pkg/deploy/config_test.go
+++ b/pkg/deploy/config_test.go
@@ -33,6 +33,22 @@ func TestParseConfig(t *testing.T) {
 	assert.Equal(t, "commonfate/okta@v1", c.Deployment.Parameters.ProviderConfiguration["okta"].Uses)
 }
 
+func AssertEqualJson(t *testing.T, wantStr string, got interface{}) {
+	gotJSON, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var wantObj interface{}
+	err = json.Unmarshal([]byte(wantStr), &wantObj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := json.Marshal(wantObj)
+
+	assert.Equal(t, string(want), string(gotJSON))
+}
+
 func TestTestCfnParams(t *testing.T) {
 	type testcase struct {
 		name string
@@ -50,7 +66,43 @@ func TestTestCfnParams(t *testing.T) {
 					},
 				},
 			},
-			want: `[{"ParameterKey":"CognitoDomainPrefix","ParameterValue":"test","ResolvedValue":null,"UsePreviousValue":null}]`,
+			want: `
+				[
+					{
+						"ParameterKey": "CognitoDomainPrefix",
+						"ParameterValue": "test",
+						"ResolvedValue": null,
+						"UsePreviousValue": null
+					}
+				]
+			`,
+		},
+		{
+			name: "IdentityGroupFilter",
+			give: Config{
+				Deployment: Deployment{
+					Parameters: Parameters{
+						CognitoDomainPrefix: "test",
+						IdentityGroupFilter: "test",
+					},
+				},
+			},
+			want: `
+				[
+					{
+						"ParameterKey": "CognitoDomainPrefix",
+						"ParameterValue": "test",
+						"ResolvedValue": null,
+						"UsePreviousValue": null
+					},
+					{
+						"ParameterKey": "IdentityGroupFilter",
+						"ParameterValue": "test",
+						"ResolvedValue": null,
+						"UsePreviousValue": null
+					}
+				]
+			`,
 		},
 		{
 			name: "provider config",
@@ -68,7 +120,22 @@ func TestTestCfnParams(t *testing.T) {
 					},
 				},
 			},
-			want: `[{"ParameterKey":"CognitoDomainPrefix","ParameterValue":"","ResolvedValue":null,"UsePreviousValue":null},{"ParameterKey":"ProviderConfiguration","ParameterValue":"{\"okta\":{\"uses\":\"commonfate/okta@v1\",\"with\":{\"orgUrl\":\"test.internal\"}}}","ResolvedValue":null,"UsePreviousValue":null}]`,
+			want: `
+				[
+					{
+						"ParameterKey": "CognitoDomainPrefix",
+						"ParameterValue": "",
+						"ResolvedValue": null,
+						"UsePreviousValue": null
+					},
+					{
+						"ParameterKey": "ProviderConfiguration",
+						"ParameterValue": "{\"okta\":{\"uses\":\"commonfate/okta@v1\",\"with\":{\"orgUrl\":\"test.internal\"}}}",
+						"ResolvedValue": null,
+						"UsePreviousValue": null
+					}
+				]
+			`,
 		},
 	}
 
@@ -78,12 +145,7 @@ func TestTestCfnParams(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			gotJSON, err := json.Marshal(got)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			assert.Equal(t, tc.want, string(gotJSON))
+			AssertEqualJson(t, tc.want, got)
 		})
 	}
 }

--- a/pkg/deploy/config_test.go
+++ b/pkg/deploy/config_test.go
@@ -45,6 +45,9 @@ func AssertEqualJson(t *testing.T, wantStr string, got interface{}) {
 		t.Fatal(err)
 	}
 	want, err := json.Marshal(wantObj)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	assert.Equal(t, string(want), string(gotJSON))
 }


### PR DESCRIPTION
### What changed?

Add the IdentityGroupFilter to CF parameter list, to
fix the issue https://github.com/common-fate/common-fate/issues/621

### Why?

Otherwise the change is ignored

### How did you test it?

Manually, using a manifest like below and running `gdeploy update`

```diff
version: 2
deployment:
  stackName: commonfate-non-prod
  account: "1234567890"
  region: us-west-2
  release: v0.15.6
  parameters:
    CognitoDomainPrefix: common-fate-non-prod-login-mycompany
    AdministratorGroupID: vhjdsfbkgbsakdng1
    IdentityProviderType: okta
    SamlSSOMetadataURL: https://mycompany-test.oktapreview.com/app/exka4ccnoe1AZdYy91d7/sso/saml/metadata
+    IdentityGroupFilter: "Okta-App.*Commonfate|commonfate_example.*"
    ProviderConfiguration:
      okta:
        uses: commonfate/okta@v1
        with:
          apiToken: awsssm:///granted/providers/okta/apiToken:1
          orgUrl: https://mycompany-test.oktapreview.com
    IdentityConfiguration:
      okta:
        apiToken: awsssm:///granted/secrets/identity/okta/token:4
        orgUrl: https://mycompany-test.oktapreview.com/
```

Checking a unit test



### Potential risks
#
none I can think about


### Is patch release candidate?

dunno

### Link to relevant docs PRs

https://github.com/common-fate/common-fate/issues/621
https://docs.commonfate.io/common-fate/sso/filtering-user-group-import