### PR TITLE
Add groups option to IdentityConfiguration to fetch only desired users

### DIFF
--- a/pkg/identity/identitysync/okta.go
+++ b/pkg/identity/identitysync/okta.go
@@ -20,14 +20,14 @@ type OktaSync struct {
 	client   *okta.Client
 	orgURL   gconfig.StringValue
 	apiToken gconfig.SecretStringValue
-	groups   gconfig.StringValue
+	groups   gconfig.OptionalStringValue
 }
 
 func (s *OktaSync) Config() gconfig.Config {
 	return gconfig.Config{
 		gconfig.StringField("orgUrl", &s.orgURL, "the Okta organization URL"),
 		gconfig.SecretStringField("apiToken", &s.apiToken, "the Okta API token", gconfig.WithNoArgs("/granted/secrets/identity/okta/token")),
-		gconfig.StringField("groups", &s.groups, "Groups that users are synced from."),
+		gconfig.OptionalStringField("groups", &s.groups, "Groups that users are synced from."),
 	}
 }
 
@@ -57,7 +57,7 @@ func (s *OktaSync) TestConfig(ctx context.Context) error {
 }
 
 // userFromOktaUser converts a Okta user to the identityprovider interface user type
-func (o *OktaSync) idpUserFromOktaUser(ctx context.Context, oktaUser *okta.User) (identity.IDPUser, error) {
+func (o *OktaSync) idpUserFromOktaUser(ctx context.Context, oktaUser *okta.User, userIdToGroupIds map[string][]string) (identity.IDPUser, error) {
 	log := logger.Get(ctx).With("okta.user_id", oktaUser.Id)
 
 	userJSON, err := json.Marshal(oktaUser)
@@ -97,12 +97,16 @@ func (o *OktaSync) idpUserFromOktaUser(ctx context.Context, oktaUser *okta.User)
 
 	log.Debug("listing groups for user")
 
-	userGroups, _, err := o.client.User.ListUserGroups(ctx, oktaUser.Id)
-	if err != nil {
-		return u, errors.Wrapf(err, "listing groups for okta user %s", oktaUser.Id)
-	}
-	for _, g := range userGroups {
-		u.Groups = append(u.Groups, g.Id)
+	if userIdToGroupIds != nil {
+		u.Groups = append(u.Groups, userIdToGroupIds[oktaUser.Id]...)
+	} else {
+		userGroups, _, err := o.client.User.ListUserGroups(ctx, oktaUser.Id)
+		if err != nil {
+			return u, errors.Wrapf(err, "listing groups for okta user %s", oktaUser.Id)
+		}
+		for _, g := range userGroups {
+			u.Groups = append(u.Groups, g.Id)
+		}
 	}
 
 	log.Debugw("finished converting okta user to internal user", "user", u)
@@ -128,7 +132,7 @@ func logResponseErr(log *zap.SugaredLogger, res *okta.Response, err error) {
 	}
 }
 
-func (o *OktaSync) ListUsers(ctx context.Context) ([]identity.IDPUser, error) {
+func (o *OktaSync) listAllUsers(ctx context.Context) ([]identity.IDPUser, error) {
 	log := logger.Get(ctx)
 
 	//get all users
@@ -136,7 +140,44 @@ func (o *OktaSync) ListUsers(ctx context.Context) ([]identity.IDPUser, error) {
 
 	log.Debugw("listing all okta users")
 
+	users, res, err := o.client.User.ListUsers(ctx, &query.Params{})
+	if err != nil {
+		// try and log the response body
+		logResponseErr(log, res, err)
+		return nil, errors.Wrap(err, "listing okta users from okta API")
+	}
+
+	log.Debugw("listed all okta users")
+
+	for res.HasNextPage() {
+		var nextUsers []*okta.User
+		res, err = res.Next(ctx, &nextUsers)
+		if err != nil {
+			logResponseErr(log, res, err)
+			return nil, err
+		}
+		users = append(users, nextUsers...)
+		log.Debugw("fetched more users", "nextPage", res.NextPage)
+	}
+
+	// convert all Okta users to internal users
+	for _, u := range users {
+		user, err := o.idpUserFromOktaUser(ctx, u, nil)
+		if err != nil {
+			return nil, errors.Wrapf(err, "converting okta user %s to internal user", u.Id)
+		}
+		idpUsers = append(idpUsers, user)
+	}
+
+	return idpUsers, nil
+}
+
+func (o *OktaSync) listUsersBasedOnGroups(ctx context.Context) ([]identity.IDPUser, error) {
+	log := logger.Get(ctx)
+	idpUsers := []identity.IDPUser{}
+
 	oktaUsers := make(map[string]*okta.User)
+	userGroupIds := make(map[string][]string)
 	for _, groupId := range strings.Split(o.groups.Get(), ",") {
 		log.Infow(fmt.Sprintf("fetching users for groupId = %s", groupId))
 		users, res, err := o.client.Group.ListGroupUsers(ctx, groupId, &query.Params{})
@@ -161,12 +202,13 @@ func (o *OktaSync) ListUsers(ctx context.Context) ([]identity.IDPUser, error) {
 
 		for _, user := range users {
 			oktaUsers[user.Id] = user
+			userGroupIds[user.Id] = append(userGroupIds[user.Id], groupId)
 		}
 	}
 
 	// convert all Okta users to internal users
 	for _, u := range oktaUsers {
-		user, err := o.idpUserFromOktaUser(ctx, u)
+		user, err := o.idpUserFromOktaUser(ctx, u, userGroupIds)
 		if err != nil {
 			return nil, errors.Wrapf(err, "converting okta user %s to internal user", u.Id)
 		}
@@ -174,6 +216,13 @@ func (o *OktaSync) ListUsers(ctx context.Context) ([]identity.IDPUser, error) {
 	}
 
 	return idpUsers, nil
+}
+
+func (o *OktaSync) ListUsers(ctx context.Context) ([]identity.IDPUser, error) {
+	if o.groups.IsSet() {
+		return o.listUsersBasedOnGroups(ctx)
+	}
+	return o.listAllUsers(ctx)
 }
 
 func (o *OktaSync) ListGroups(ctx context.Context) ([]identity.IDPGroup, error) {


### PR DESCRIPTION
### What changed?
This PR adds an optional field `groups` for `IdentityConfiguration` config. 

### Why?
We faced Okta rate limits, because commonfate called `ListUserGroups` for every user in org. See for more details - https://commonfatecommunity.slack.com/archives/C03SG8PPPH7/p1695293237007429 and https://github.com/common-fate/common-fate/issues/620

### How did you test it?
We tested it in our local environment. Unit tests - TBD.

### Potential risks
It shouldn't affect configurations that have been created before, because we keep the old behaviour for configuration without `groups` field.

### Is patch release candidate?
No

