### PR TITLE
Add vpc to target granter lambda

### DIFF
--- a/deploy/infra/bin/common-fate.ts
+++ b/deploy/infra/bin/common-fate.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 import { App, DefaultStackSynthesizer } from "aws-cdk-lib";
-import {Aws} from 'aws-cdk-lib/core'
 import "source-map-support/register";
 import { CommonFateStackDev } from "../lib/common-fate-stack-dev";
 import { CommonFateStackProd } from "../lib/common-fate-stack-prod";
@@ -9,7 +8,6 @@ import {
   DevEnvironments,
 } from "../lib/helpers/dev-accounts";
 import { IdentityProviderRegistry } from "../lib/helpers/registry";
-// import * as process from "process";
 
 const app = new App();
 const stage = app.node.tryGetContext("stage");

--- a/deploy/infra/bin/common-fate.ts
+++ b/deploy/infra/bin/common-fate.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { App, DefaultStackSynthesizer } from "aws-cdk-lib";
+import {Aws} from 'aws-cdk-lib/core'
 import "source-map-support/register";
 import { CommonFateStackDev } from "../lib/common-fate-stack-dev";
 import { CommonFateStackProd } from "../lib/common-fate-stack-prod";
@@ -8,6 +9,7 @@ import {
   DevEnvironments,
 } from "../lib/helpers/dev-accounts";
 import { IdentityProviderRegistry } from "../lib/helpers/registry";
+// import * as process from "process";
 
 const app = new App();
 const stage = app.node.tryGetContext("stage");
@@ -46,6 +48,8 @@ const analyticsDeploymentStage = app.node.tryGetContext(
   "analyticsDeploymentStage"
 );
 const identityGroupFilter = app.node.tryGetContext("identityGroupFilter");
+const subnetIds = app.node.tryGetContext("subnetIds");
+const securityGroups = app.node.tryGetContext("securityGroups");
 
 let shouldRunCronHealthCheckCacheSync = app.node.tryGetContext(
   "enableCronHealthCheck"
@@ -77,7 +81,6 @@ if (stackTarget === "dev") {
     }
     devConfig = conf;
   }
-
   // I don't think we can change the same of this stack without it completely disrupting existing deployments.
   // So for now, we will stick with GrantedDev and Granted rather than CommonFate
   new CommonFateStackDev(app, "GrantedDev", {
@@ -108,6 +111,8 @@ if (stackTarget === "dev") {
     idpSyncSchedule: idpSyncSchedule || "rate(5 minutes)",
     idpSyncTimeoutSeconds: idpSyncTimeoutSeconds || 30,
     autoApprovalLambdaARN: autoApprovalLambdaARN,
+    subnetIds: subnetIds || "",
+    securityGroups: securityGroups || "",
   });
 } else if (stackTarget === "prod") {
   new CommonFateStackProd(app, "Granted", {

--- a/deploy/infra/lib/common-fate-stack-dev.ts
+++ b/deploy/infra/lib/common-fate-stack-dev.ts
@@ -15,6 +15,7 @@ import { IdentityProviderTypes } from "./helpers/registry";
 import { Governance } from "./constructs/governance";
 import { TargetGroupGranter } from "./constructs/targetgroup-granter";
 import { CfnCondition } from "aws-cdk-lib";
+import { VpcConfig } from "./helpers/base-lambda";
 
 interface Props extends cdk.StackProps {
   stage: string;
@@ -85,20 +86,10 @@ export class CommonFateStackDev extends cdk.Stack {
       }
     );
 
-    const vpcConfig = cdk.Fn.conditionIf(
-      attachLambdaToVpcCondition.logicalId,
-      {
-        SubnetIds: props.subnetIds.split(","),
-        SecurityGroupIds: props.securityGroups.split(","),
-      },
-      // Instead of using AWS::NoValue, we use [] because
-      // if we use AWS::NoValue and the subnets and security groups have already been attached,
-      // they will not be overwritten.
-      {
-        SubnetIds: [],
-        SecurityGroupIds: [],
-      }
-    );
+    const vpcConfig: VpcConfig = {
+      subnetIds: cdk.Fn.conditionIf(attachLambdaToVpcCondition.logicalId, props.subnetIds.split(","), []),
+      securityGroupIds: cdk.Fn.conditionIf(attachLambdaToVpcCondition.logicalId, props.securityGroups.split(","), []),
+    }
 
 
     const db = new Database(this, "Database", {

--- a/deploy/infra/lib/common-fate-stack-dev.ts
+++ b/deploy/infra/lib/common-fate-stack-dev.ts
@@ -14,9 +14,7 @@ import { generateOutputs } from "./helpers/outputs";
 import { IdentityProviderTypes } from "./helpers/registry";
 import { Governance } from "./constructs/governance";
 import { TargetGroupGranter } from "./constructs/targetgroup-granter";
-import { Vpc } from 'aws-cdk-lib/aws-ec2';
-import * as console from "console";
-import {CfnCondition, CfnParameter, Stack} from "aws-cdk-lib";
+import { CfnCondition } from "aws-cdk-lib";
 
 interface Props extends cdk.StackProps {
   stage: string;
@@ -77,30 +75,30 @@ export class CommonFateStackDev extends cdk.Stack {
     } = props;
     const appName = `common-fate-${stage}`;
     const attachLambdaToVpcCondition = new CfnCondition(
-        this,
-        "AttachLambdaToVpcCondition",
-        {
-          expression: cdk.Fn.conditionAnd(
-              cdk.Fn.conditionNot(cdk.Fn.conditionEquals(props.subnetIds, "")),
-              cdk.Fn.conditionNot(cdk.Fn.conditionEquals(props.securityGroups, ""))
-          )
-        }
-    )
+      this,
+      "AttachLambdaToVpcCondition",
+      {
+        expression: cdk.Fn.conditionAnd(
+          cdk.Fn.conditionNot(cdk.Fn.conditionEquals(props.subnetIds, "")),
+          cdk.Fn.conditionNot(cdk.Fn.conditionEquals(props.securityGroups, ""))
+        ),
+      }
+    );
 
     const vpcConfig = cdk.Fn.conditionIf(
-        attachLambdaToVpcCondition.logicalId,
-        {
-          SubnetIds: props.subnetIds.split(","),
-          SecurityGroupIds: props.securityGroups.split(","),
-        },
-        // Instead of using AWS::NoValue, we use [] because
-        // if we use AWS::NoValue and the subnets and security groups have already been attached,
-        // they will not be overwritten.
-        {
-          SubnetIds: [],
-          SecurityGroupIds: [],
-        }
-    )
+      attachLambdaToVpcCondition.logicalId,
+      {
+        SubnetIds: props.subnetIds.split(","),
+        SecurityGroupIds: props.securityGroups.split(","),
+      },
+      // Instead of using AWS::NoValue, we use [] because
+      // if we use AWS::NoValue and the subnets and security groups have already been attached,
+      // they will not be overwritten.
+      {
+        SubnetIds: [],
+        SecurityGroupIds: [],
+      }
+    );
 
 
     const db = new Database(this, "Database", {

--- a/deploy/infra/lib/common-fate-stack-prod.ts
+++ b/deploy/infra/lib/common-fate-stack-prod.ts
@@ -7,7 +7,7 @@ import { AppFrontend } from "./constructs/app-frontend";
 import { WebUserPool } from "./constructs/app-user-pool";
 import * as kms from "aws-cdk-lib/aws-kms";
 
-import {CfnCondition, CfnParameter} from "aws-cdk-lib";
+import { CfnCondition, CfnParameter } from "aws-cdk-lib";
 import { EventBus } from "./constructs/events";
 import { ProductionFrontendDeployer } from "./constructs/production-frontend-deployer";
 import { generateOutputs } from "./helpers/outputs";
@@ -217,51 +217,48 @@ export class CommonFateStackProd extends cdk.Stack {
         }
     );
 
-    const subnetIds = new CfnParameter(
-        this,
-        "SubnetIds",
-        {
-          type: "String",
-          description: "A list of subnet ids that are used by lambda functions",
-          default: "",
-        }
-    );
+    const subnetIds = new CfnParameter(this, "SubnetIds", {
+      type: "String",
+      description: "A list of subnet ids that are used by lambda functions",
+      default: "",
+    });
 
-    const securityGroups = new CfnParameter(
-        this,
-        "SecurityGroups",
-        {
-          type: "String",
-          description: "A list of security groups that are used by lambda functions",
-          default: "",
-        }
-    );
+    const securityGroups = new CfnParameter(this, "SecurityGroups", {
+      type: "String",
+      description:
+        "A list of security groups that are used by lambda functions",
+      default: "",
+    });
 
     const attachLambdaToVpcCondition = new CfnCondition(
-        this,
-        "AttachLambdaToVpcCondition",
-        {
-          expression: cdk.Fn.conditionAnd(
-              cdk.Fn.conditionNot(cdk.Fn.conditionEquals(subnetIds.valueAsString, "")),
-              cdk.Fn.conditionNot(cdk.Fn.conditionEquals(securityGroups.valueAsString, ""))
+      this,
+      "AttachLambdaToVpcCondition",
+      {
+        expression: cdk.Fn.conditionAnd(
+          cdk.Fn.conditionNot(
+            cdk.Fn.conditionEquals(subnetIds.valueAsString, "")
+          ),
+          cdk.Fn.conditionNot(
+            cdk.Fn.conditionEquals(securityGroups.valueAsString, "")
           )
-        }
-    )
+        ),
+      }
+    );
 
     const vpcConfig = cdk.Fn.conditionIf(
-        attachLambdaToVpcCondition.logicalId,
-        {
-          SubnetIds: subnetIds.valueAsString.split(","),
-          SecurityGroupIds: subnetIds.valueAsString.split(","),
-        },
-        // Instead of using AWS::NoValue, we use [] because
-        // if we use AWS::NoValue and the subnets and security groups have already been attached,
-        // they will not be overwritten.
-        {
-          SubnetIds: [],
-          SecurityGroupIds: [],
-        }
-    )
+      attachLambdaToVpcCondition.logicalId,
+      {
+        SubnetIds: subnetIds.valueAsString.split(","),
+        SecurityGroupIds: subnetIds.valueAsString.split(","),
+      },
+      // Instead of using AWS::NoValue, we use [] because
+      // if we use AWS::NoValue and the subnets and security groups have already been attached,
+      // they will not be overwritten.
+      {
+        SubnetIds: [],
+        SecurityGroupIds: [],
+      }
+    );
 
     const appName = this.stackName + suffix.valueAsString;
 

--- a/deploy/infra/lib/common-fate-stack-prod.ts
+++ b/deploy/infra/lib/common-fate-stack-prod.ts
@@ -213,9 +213,19 @@ export class CommonFateStackProd extends cdk.Stack {
         {
           type: "String",
           description: "ARN of a lambda function that is triggered when an access request is created.",
+            default: "",
+        }
+    );
+
+    const lambdaVpcId = new CfnParameter(
+        this,
+        "LambdaVpcId",
+        {
+          type: "String",
+          description: "VPC that grant lambda will be attached to.",
           default: "",
         }
-    )
+    );
 
     const appName = this.stackName + suffix.valueAsString;
 
@@ -282,6 +292,7 @@ export class CommonFateStackProd extends cdk.Stack {
         eventBus: events.getEventBus(),
         eventBusSourceName: events.getEventBusSourceName(),
         dynamoTable: db.getTable(),
+        lambdaVpcId: lambdaVpcId.valueAsString
       }
     );
     const appBackend = new AppBackend(this, "API", {

--- a/deploy/infra/lib/common-fate-stack-prod.ts
+++ b/deploy/infra/lib/common-fate-stack-prod.ts
@@ -214,7 +214,7 @@ export class CommonFateStackProd extends cdk.Stack {
         {
           type: "String",
           description: "ARN of a lambda function that is triggered when an access request is created.",
-            default: "",
+          default: "",
         }
     );
 

--- a/deploy/infra/lib/common-fate-stack-prod.ts
+++ b/deploy/infra/lib/common-fate-stack-prod.ts
@@ -18,6 +18,7 @@ import {
 import { Database } from "./constructs/database";
 import { Governance } from "./constructs/governance";
 import { TargetGroupGranter } from "./constructs/targetgroup-granter";
+import { VpcConfig } from "./helpers/base-lambda";
 
 interface Props extends cdk.StackProps {
   productionReleasesBucket: string;
@@ -245,20 +246,10 @@ export class CommonFateStackProd extends cdk.Stack {
       }
     );
 
-    const vpcConfig = cdk.Fn.conditionIf(
-      attachLambdaToVpcCondition.logicalId,
-      {
-        SubnetIds: subnetIds.valueAsString.split(","),
-        SecurityGroupIds: subnetIds.valueAsString.split(","),
-      },
-      // Instead of using AWS::NoValue, we use [] because
-      // if we use AWS::NoValue and the subnets and security groups have already been attached,
-      // they will not be overwritten.
-      {
-        SubnetIds: [],
-        SecurityGroupIds: [],
-      }
-    );
+    const vpcConfig: VpcConfig = {
+      subnetIds: cdk.Fn.conditionIf(attachLambdaToVpcCondition.logicalId, subnetIds.valueAsString.split(","), []),
+      securityGroupIds: cdk.Fn.conditionIf(attachLambdaToVpcCondition.logicalId, securityGroups.valueAsString.split(","), [])
+    }
 
     const appName = this.stackName + suffix.valueAsString;
 

--- a/deploy/infra/lib/constructs/access-handler.ts
+++ b/deploy/infra/lib/constructs/access-handler.ts
@@ -7,7 +7,7 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 import * as path from "path";
 import { Granter } from "./granter";
-import { BaseLambdaFunction } from "../helpers/base-lambda";
+import { BaseLambdaFunction, VpcConfig } from "../helpers/base-lambda";
 interface Props {
   appName: string;
   eventBusSourceName: string;
@@ -16,7 +16,7 @@ interface Props {
   remoteConfigHeaders: string;
   /** A JSON payload of the access provider configuration. */
   providerConfig: string;
-  vpcConfig: any;
+  vpcConfig: VpcConfig;
 }
 
 export class AccessHandler extends Construct {

--- a/deploy/infra/lib/constructs/access-handler.ts
+++ b/deploy/infra/lib/constructs/access-handler.ts
@@ -7,7 +7,7 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 import * as path from "path";
 import { Granter } from "./granter";
-import {BaseLambdaFunction} from "../helpers/base-lambda";
+import { BaseLambdaFunction } from "../helpers/base-lambda";
 interface Props {
   appName: string;
   eventBusSourceName: string;
@@ -95,23 +95,23 @@ export class AccessHandler extends Construct {
 
     this._lambda = new BaseLambdaFunction(this, "RestAPIHandlerFunction", {
       functionProps: {
-      code,
-      timeout: Duration.seconds(60),
-      environment: {
-        COMMONFATE_ACCESS_HANDLER_RUNTIME: "lambda",
-        COMMONFATE_STATE_MACHINE_ARN: this._granter.getStateMachineARN(),
-        COMMONFATE_EVENT_BUS_ARN: props.eventBus.eventBusArn,
-        COMMONFATE_EVENT_BUS_SOURCE: props.eventBusSourceName,
-        COMMONFATE_PROVIDER_CONFIG: props.providerConfig,
-        COMMONFATE_ACCESS_REMOTE_CONFIG_URL: props.remoteConfigUrl,
-        COMMONFATE_REMOTE_CONFIG_HEADERS: props.remoteConfigHeaders,
+        code,
+        timeout: Duration.seconds(60),
+        environment: {
+          COMMONFATE_ACCESS_HANDLER_RUNTIME: "lambda",
+          COMMONFATE_STATE_MACHINE_ARN: this._granter.getStateMachineARN(),
+          COMMONFATE_EVENT_BUS_ARN: props.eventBus.eventBusArn,
+          COMMONFATE_EVENT_BUS_SOURCE: props.eventBusSourceName,
+          COMMONFATE_PROVIDER_CONFIG: props.providerConfig,
+          COMMONFATE_ACCESS_REMOTE_CONFIG_URL: props.remoteConfigUrl,
+          COMMONFATE_REMOTE_CONFIG_HEADERS: props.remoteConfigHeaders,
+        },
+        runtime: lambda.Runtime.GO_1_X,
+        handler: "access-handler",
+        role: this._executionRole,
       },
-      runtime: lambda.Runtime.GO_1_X,
-      handler: "access-handler",
-      role: this._executionRole,
-    },
-        vpcConfig: props.vpcConfig},
-    );
+      vpcConfig: props.vpcConfig,
+    });
 
     this._apigateway = new apigateway.RestApi(this, "RestAPI", {
       restApiName: this._restApiName,

--- a/deploy/infra/lib/constructs/app-backend.ts
+++ b/deploy/infra/lib/constructs/app-backend.ts
@@ -22,7 +22,7 @@ import {
   grantAssumeHandlerRole,
   grantAssumeIdentitySyncRole,
 } from "../helpers/permissions";
-import { BaseLambdaFunction } from "../helpers/base-lambda";
+import { BaseLambdaFunction, VpcConfig } from "../helpers/base-lambda";
 
 interface Props {
   appName: string;
@@ -53,7 +53,7 @@ interface Props {
   targetGroupGranter: TargetGroupGranter;
   identityGroupFilter: string;
   autoApprovalLambdaARN: string;
-  vpcConfig: any;
+  vpcConfig: VpcConfig;
 }
 
 export class AppBackend extends Construct {

--- a/deploy/infra/lib/constructs/app-backend.ts
+++ b/deploy/infra/lib/constructs/app-backend.ts
@@ -1,5 +1,5 @@
 import * as cdk from "aws-cdk-lib";
-import {aws_vpclattice, CfnCondition, Duration, Stack} from "aws-cdk-lib";
+import { CfnCondition, Duration, Stack } from "aws-cdk-lib";
 import * as apigateway from "aws-cdk-lib/aws-apigateway";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import { EventBus } from "aws-cdk-lib/aws-events";
@@ -22,7 +22,7 @@ import {
   grantAssumeHandlerRole,
   grantAssumeIdentitySyncRole,
 } from "../helpers/permissions";
-import {BaseLambdaFunction} from "../helpers/base-lambda";
+import { BaseLambdaFunction } from "../helpers/base-lambda";
 
 interface Props {
   appName: string;
@@ -152,7 +152,7 @@ export class AppBackend extends Construct {
         runtime: lambda.Runtime.GO_1_X,
         handler: "commonfate",
       },
-      vpcConfig: props.vpcConfig
+      vpcConfig: props.vpcConfig,
     });
 
     this._KMSkey.grantEncryptDecrypt(this._lambda);

--- a/deploy/infra/lib/constructs/cache-sync.ts
+++ b/deploy/infra/lib/constructs/cache-sync.ts
@@ -39,7 +39,7 @@ export class CacheSync extends Construct {
         runtime: lambda.Runtime.GO_1_X,
         handler: "cache-sync",
       },
-      vpcConfig: props.vpcConfig
+      vpcConfig: props.vpcConfig,
     });
 
     props.dynamoTable.grantReadWriteData(this._lambda);

--- a/deploy/infra/lib/constructs/cache-sync.ts
+++ b/deploy/infra/lib/constructs/cache-sync.ts
@@ -8,14 +8,14 @@ import { Construct } from "constructs";
 import * as path from "path";
 import { AccessHandler } from "./access-handler";
 import { grantAssumeHandlerRole } from "../helpers/permissions";
-import { BaseLambdaFunction } from "../helpers/base-lambda";
+import { BaseLambdaFunction, VpcConfig } from "../helpers/base-lambda";
 
 interface Props {
   dynamoTable: Table;
   accessHandler: AccessHandler;
   shouldRunAsCron: boolean;
   identityGroupFilter: string;
-  vpcConfig: any;
+  vpcConfig: VpcConfig;
 }
 
 export class CacheSync extends Construct {

--- a/deploy/infra/lib/constructs/event-handler.ts
+++ b/deploy/infra/lib/constructs/event-handler.ts
@@ -5,11 +5,13 @@ import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 import * as path from "path";
+import {BaseLambdaFunction} from "../helpers/base-lambda";
 
 interface Props {
   eventBusSourceName: string;
   eventBus: EventBus;
   dynamoTable: Table;
+  vpcConfig: any;
 }
 export class EventHandler extends Construct {
   private _lambda: lambda.Function;
@@ -18,14 +20,17 @@ export class EventHandler extends Construct {
     const code = lambda.Code.fromAsset(
       path.join(__dirname, "..", "..", "..", "..", "bin", "event-handler.zip")
     );
-    this._lambda = new lambda.Function(this, "Function", {
-      code,
-      timeout: Duration.seconds(20),
-      environment: {
-        COMMONFATE_TABLE_NAME: props.dynamoTable.tableName,
+    this._lambda = new BaseLambdaFunction(this, "Function", {
+      functionProps: {
+        code,
+        timeout: Duration.seconds(20),
+        environment: {
+          COMMONFATE_TABLE_NAME: props.dynamoTable.tableName,
+        },
+        runtime: lambda.Runtime.GO_1_X,
+        handler: "event-handler",
       },
-      runtime: lambda.Runtime.GO_1_X,
-      handler: "event-handler",
+      vpcConfig: props.vpcConfig,
     });
 
     new Rule(this, "EventBusRule", {

--- a/deploy/infra/lib/constructs/event-handler.ts
+++ b/deploy/infra/lib/constructs/event-handler.ts
@@ -5,13 +5,13 @@ import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 import * as path from "path";
-import { BaseLambdaFunction } from "../helpers/base-lambda";
+import { BaseLambdaFunction, VpcConfig } from "../helpers/base-lambda";
 
 interface Props {
   eventBusSourceName: string;
   eventBus: EventBus;
   dynamoTable: Table;
-  vpcConfig: any;
+  vpcConfig: VpcConfig;
 }
 export class EventHandler extends Construct {
   private _lambda: lambda.Function;

--- a/deploy/infra/lib/constructs/event-handler.ts
+++ b/deploy/infra/lib/constructs/event-handler.ts
@@ -5,7 +5,7 @@ import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 import * as path from "path";
-import {BaseLambdaFunction} from "../helpers/base-lambda";
+import { BaseLambdaFunction } from "../helpers/base-lambda";
 
 interface Props {
   eventBusSourceName: string;

--- a/deploy/infra/lib/constructs/governance.ts
+++ b/deploy/infra/lib/constructs/governance.ts
@@ -7,6 +7,7 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 import * as path from "path";
 import { AccessHandler } from "./access-handler";
+import {BaseLambdaFunction} from "../helpers/base-lambda";
 
 interface Props {
   appName: string;
@@ -14,6 +15,7 @@ interface Props {
   providerConfig: string;
   dynamoTable: dynamodb.Table;
   kmsKey: cdk.aws_kms.Key;
+  vpcConfig: any;
 }
 
 export class Governance extends Construct {
@@ -39,23 +41,26 @@ export class Governance extends Construct {
       path.join(__dirname, "..", "..", "..", "..", "bin", "governance.zip")
     );
 
-    this._governanceLambda = new lambda.Function(
+    this._governanceLambda = new BaseLambdaFunction(
       this,
       "GovernanceAPIHandlerFunction",
-      {
-        code,
-        timeout: Duration.seconds(60),
-        environment: {
-          COMMONFATE_TABLE_NAME: this._dynamoTable.tableName,
-          COMMONFATE_MOCK_ACCESS_HANDLER: "false",
-          COMMONFATE_ACCESS_HANDLER_URL: props.accessHandler.getApiUrl(),
-          COMMONFATE_PROVIDER_CONFIG: props.providerConfig,
+        {
+          functionProps: {
+            code,
+            timeout: Duration.seconds(60),
+            environment: {
+              COMMONFATE_TABLE_NAME: this._dynamoTable.tableName,
+              COMMONFATE_MOCK_ACCESS_HANDLER: "false",
+              COMMONFATE_ACCESS_HANDLER_URL: props.accessHandler.getApiUrl(),
+              COMMONFATE_PROVIDER_CONFIG: props.providerConfig,
 
-          COMMONFATE_PAGINATION_KMS_KEY_ARN: this._KMSkey.keyArn,
-        },
-        runtime: lambda.Runtime.GO_1_X,
-        handler: "governance",
-      }
+              COMMONFATE_PAGINATION_KMS_KEY_ARN: this._KMSkey.keyArn,
+            },
+            runtime: lambda.Runtime.GO_1_X,
+            handler: "governance",
+          },
+          vpcConfig: props.vpcConfig,
+        }
     );
     this._dynamoTable.grantReadWriteData(this._governanceLambda);
     this._KMSkey.grantEncryptDecrypt(this._governanceLambda);

--- a/deploy/infra/lib/constructs/governance.ts
+++ b/deploy/infra/lib/constructs/governance.ts
@@ -7,7 +7,7 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 import * as path from "path";
 import { AccessHandler } from "./access-handler";
-import {BaseLambdaFunction} from "../helpers/base-lambda";
+import { BaseLambdaFunction } from "../helpers/base-lambda";
 
 interface Props {
   appName: string;
@@ -44,23 +44,23 @@ export class Governance extends Construct {
     this._governanceLambda = new BaseLambdaFunction(
       this,
       "GovernanceAPIHandlerFunction",
-        {
-          functionProps: {
-            code,
-            timeout: Duration.seconds(60),
-            environment: {
-              COMMONFATE_TABLE_NAME: this._dynamoTable.tableName,
-              COMMONFATE_MOCK_ACCESS_HANDLER: "false",
-              COMMONFATE_ACCESS_HANDLER_URL: props.accessHandler.getApiUrl(),
-              COMMONFATE_PROVIDER_CONFIG: props.providerConfig,
+      {
+        functionProps: {
+          code,
+          timeout: Duration.seconds(60),
+          environment: {
+            COMMONFATE_TABLE_NAME: this._dynamoTable.tableName,
+            COMMONFATE_MOCK_ACCESS_HANDLER: "false",
+            COMMONFATE_ACCESS_HANDLER_URL: props.accessHandler.getApiUrl(),
+            COMMONFATE_PROVIDER_CONFIG: props.providerConfig,
 
-              COMMONFATE_PAGINATION_KMS_KEY_ARN: this._KMSkey.keyArn,
-            },
-            runtime: lambda.Runtime.GO_1_X,
-            handler: "governance",
+            COMMONFATE_PAGINATION_KMS_KEY_ARN: this._KMSkey.keyArn,
           },
-          vpcConfig: props.vpcConfig,
-        }
+          runtime: lambda.Runtime.GO_1_X,
+          handler: "governance",
+        },
+        vpcConfig: props.vpcConfig,
+      }
     );
     this._dynamoTable.grantReadWriteData(this._governanceLambda);
     this._KMSkey.grantEncryptDecrypt(this._governanceLambda);

--- a/deploy/infra/lib/constructs/governance.ts
+++ b/deploy/infra/lib/constructs/governance.ts
@@ -7,7 +7,7 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 import * as path from "path";
 import { AccessHandler } from "./access-handler";
-import { BaseLambdaFunction } from "../helpers/base-lambda";
+import { BaseLambdaFunction, VpcConfig } from "../helpers/base-lambda";
 
 interface Props {
   appName: string;
@@ -15,7 +15,7 @@ interface Props {
   providerConfig: string;
   dynamoTable: dynamodb.Table;
   kmsKey: cdk.aws_kms.Key;
-  vpcConfig: any;
+  vpcConfig: VpcConfig;
 }
 
 export class Governance extends Construct {

--- a/deploy/infra/lib/constructs/granter.ts
+++ b/deploy/infra/lib/constructs/granter.ts
@@ -5,7 +5,7 @@ import { Construct } from "constructs";
 import { Duration, Stack } from "aws-cdk-lib";
 import * as path from "path";
 import { EventBus } from "aws-cdk-lib/aws-events";
-import { BaseLambdaFunction } from "../helpers/base-lambda";
+import { BaseLambdaFunction, VpcConfig } from "../helpers/base-lambda";
 
 interface Props {
   eventBusSourceName: string;
@@ -14,7 +14,7 @@ interface Props {
   executionRole: iam.Role;
   remoteConfigUrl: string;
   remoteConfigHeaders: string;
-  vpcConfig: any;
+  vpcConfig: VpcConfig;
 }
 export class Granter extends Construct {
   private _stateMachine: sfn.StateMachine;

--- a/deploy/infra/lib/constructs/granter.ts
+++ b/deploy/infra/lib/constructs/granter.ts
@@ -5,7 +5,7 @@ import { Construct } from "constructs";
 import { Duration, Stack } from "aws-cdk-lib";
 import * as path from "path";
 import { EventBus } from "aws-cdk-lib/aws-events";
-import {BaseLambdaFunction} from "../helpers/base-lambda";
+import { BaseLambdaFunction } from "../helpers/base-lambda";
 
 interface Props {
   eventBusSourceName: string;

--- a/deploy/infra/lib/constructs/healthchecker.ts
+++ b/deploy/infra/lib/constructs/healthchecker.ts
@@ -7,7 +7,7 @@ import { Construct } from "constructs";
 import * as path from "path";
 import { PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { grantAssumeHandlerRole } from "../helpers/permissions";
-import {BaseLambdaFunction} from "../helpers/base-lambda";
+import { BaseLambdaFunction } from "../helpers/base-lambda";
 
 interface Props {
   dynamoTable: Table;
@@ -25,19 +25,18 @@ export class HealthChecker extends Construct {
       path.join(__dirname, "..", "..", "..", "..", "bin", "healthcheck.zip")
     );
 
-    this._lambda = new BaseLambdaFunction(this, "HandlerFunction",
-        {
-          functionProps: {
-            code,
-            timeout: Duration.minutes(1),
-            environment: {
-              COMMONFATE_TABLE_NAME: props.dynamoTable.tableName,
-            },
-            runtime: lambda.Runtime.GO_1_X,
-            handler: "healthcheck",
-          },
-          vpcConfig: props.vpcConfig,
-        });
+    this._lambda = new BaseLambdaFunction(this, "HandlerFunction", {
+      functionProps: {
+        code,
+        timeout: Duration.minutes(1),
+        environment: {
+          COMMONFATE_TABLE_NAME: props.dynamoTable.tableName,
+        },
+        runtime: lambda.Runtime.GO_1_X,
+        handler: "healthcheck",
+      },
+      vpcConfig: props.vpcConfig,
+    });
 
     props.dynamoTable.grantReadWriteData(this._lambda);
 

--- a/deploy/infra/lib/constructs/healthchecker.ts
+++ b/deploy/infra/lib/constructs/healthchecker.ts
@@ -5,14 +5,13 @@ import * as targets from "aws-cdk-lib/aws-events-targets";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 import * as path from "path";
-import { PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { grantAssumeHandlerRole } from "../helpers/permissions";
-import { BaseLambdaFunction } from "../helpers/base-lambda";
+import { BaseLambdaFunction, VpcConfig } from "../helpers/base-lambda";
 
 interface Props {
   dynamoTable: Table;
   shouldRunAsCron: boolean;
-  vpcConfig: any;
+  vpcConfig: VpcConfig;
 }
 
 export class HealthChecker extends Construct {

--- a/deploy/infra/lib/constructs/healthchecker.ts
+++ b/deploy/infra/lib/constructs/healthchecker.ts
@@ -7,10 +7,12 @@ import { Construct } from "constructs";
 import * as path from "path";
 import { PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { grantAssumeHandlerRole } from "../helpers/permissions";
+import {BaseLambdaFunction} from "../helpers/base-lambda";
 
 interface Props {
   dynamoTable: Table;
   shouldRunAsCron: boolean;
+  vpcConfig: any;
 }
 
 export class HealthChecker extends Construct {
@@ -23,15 +25,19 @@ export class HealthChecker extends Construct {
       path.join(__dirname, "..", "..", "..", "..", "bin", "healthcheck.zip")
     );
 
-    this._lambda = new lambda.Function(this, "HandlerFunction", {
-      code,
-      timeout: Duration.minutes(1),
-      environment: {
-        COMMONFATE_TABLE_NAME: props.dynamoTable.tableName,
-      },
-      runtime: lambda.Runtime.GO_1_X,
-      handler: "healthcheck",
-    });
+    this._lambda = new BaseLambdaFunction(this, "HandlerFunction",
+        {
+          functionProps: {
+            code,
+            timeout: Duration.minutes(1),
+            environment: {
+              COMMONFATE_TABLE_NAME: props.dynamoTable.tableName,
+            },
+            runtime: lambda.Runtime.GO_1_X,
+            handler: "healthcheck",
+          },
+          vpcConfig: props.vpcConfig,
+        });
 
     props.dynamoTable.grantReadWriteData(this._lambda);
 

--- a/deploy/infra/lib/constructs/idp-sync.ts
+++ b/deploy/infra/lib/constructs/idp-sync.ts
@@ -8,7 +8,7 @@ import { Construct } from "constructs";
 import * as path from "path";
 import { grantAssumeIdentitySyncRole } from "../helpers/permissions";
 import { WebUserPool } from "./app-user-pool";
-import { BaseLambdaFunction } from "../helpers/base-lambda";
+import { BaseLambdaFunction, VpcConfig } from "../helpers/base-lambda";
 
 interface Props {
   dynamoTable: Table;
@@ -22,7 +22,7 @@ interface Props {
   idpSyncTimeoutSeconds: number;
   idpSyncSchedule: string;
   idpSyncMemory: number;
-  vpcConfig: any;
+  vpcConfig: VpcConfig;
 }
 
 export class IdpSync extends Construct {

--- a/deploy/infra/lib/constructs/idp-sync.ts
+++ b/deploy/infra/lib/constructs/idp-sync.ts
@@ -8,7 +8,7 @@ import { Construct } from "constructs";
 import * as path from "path";
 import { grantAssumeIdentitySyncRole } from "../helpers/permissions";
 import { WebUserPool } from "./app-user-pool";
-import {BaseLambdaFunction} from "../helpers/base-lambda";
+import { BaseLambdaFunction } from "../helpers/base-lambda";
 
 interface Props {
   dynamoTable: Table;

--- a/deploy/infra/lib/constructs/notifiers.ts
+++ b/deploy/infra/lib/constructs/notifiers.ts
@@ -8,7 +8,7 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 import * as path from "path";
 import { WebUserPool } from "./app-user-pool";
-import { BaseLambdaFunction } from "../helpers/base-lambda";
+import { BaseLambdaFunction, VpcConfig } from "../helpers/base-lambda";
 
 interface Props {
   eventBusSourceName: string;
@@ -19,7 +19,7 @@ interface Props {
   notificationsConfig: string;
   remoteConfigUrl: string;
   remoteConfigHeaders: string;
-  vpcConfig: any;
+  vpcConfig: VpcConfig;
 }
 export class Notifiers extends Construct {
   private _slackLambda: lambda.Function;

--- a/deploy/infra/lib/constructs/notifiers.ts
+++ b/deploy/infra/lib/constructs/notifiers.ts
@@ -8,7 +8,7 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 import * as path from "path";
 import { WebUserPool } from "./app-user-pool";
-import {BaseLambdaFunction} from "../helpers/base-lambda";
+import { BaseLambdaFunction } from "../helpers/base-lambda";
 
 interface Props {
   eventBusSourceName: string;

--- a/deploy/infra/lib/constructs/production-frontend-deployer.ts
+++ b/deploy/infra/lib/constructs/production-frontend-deployer.ts
@@ -4,7 +4,7 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import { Construct } from "constructs";
 import * as path from "path";
-import { BaseLambdaFunction } from "../helpers/base-lambda";
+import { BaseLambdaFunction, VpcConfig } from "../helpers/base-lambda";
 
 interface Props {
   cfReleaseBucket: string;
@@ -17,7 +17,7 @@ interface Props {
   frontendDomain: string;
   cloudfrontDistributionId: string;
   apiUrl: string;
-  vpcConfig: any;
+  vpcConfig: VpcConfig;
 }
 export class ProductionFrontendDeployer extends Construct {
   private _lambda: lambda.Function;

--- a/deploy/infra/lib/constructs/production-frontend-deployer.ts
+++ b/deploy/infra/lib/constructs/production-frontend-deployer.ts
@@ -4,6 +4,7 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import { Construct } from "constructs";
 import * as path from "path";
+import {BaseLambdaFunction} from "../helpers/base-lambda";
 
 interface Props {
   cfReleaseBucket: string;
@@ -16,6 +17,7 @@ interface Props {
   frontendDomain: string;
   cloudfrontDistributionId: string;
   apiUrl: string;
+  vpcConfig: any;
 }
 export class ProductionFrontendDeployer extends Construct {
   private _lambda: lambda.Function;
@@ -32,27 +34,30 @@ export class ProductionFrontendDeployer extends Construct {
         "frontend-deployer.zip"
       )
     );
-    this._lambda = new lambda.Function(this, "Function", {
-      code,
-      // The frontend deployer has a 7 minute timeout
-      // internally, the deployer has a 5 minute retry backoff around the invalidation cloudfront method
-      // at worst execution would take around 5 mins 30s
-      timeout: Duration.seconds(60 * 7),
-      environment: {
-        CF_RELEASES_BUCKET: props.cfReleaseBucket,
-        CF_RELEASES_FRONTEND_ASSET_OBJECT_PREFIX:
-          props.cfReleaseBucketFrontendAssetObjectPrefix,
-        COMMONFATE_FRONTEND_BUCKET: props.frontendBucket.bucketName,
-        COMMONFATE_COGNITO_USER_POOL_ID: props.cognitoUserPoolId,
-        COMMONFATE_COGNITO_CLIENT_ID: props.cognitoClientId,
-        COMMONFATE_USER_POOL_DOMAIN: props.userPoolDomain,
-        COMMONFATE_FRONTEND_DOMAIN: props.frontendDomain,
-        COMMONFATE_CLOUDFRONT_DISTRIBUTION_ID: props.cloudfrontDistributionId,
-        COMMONFATE_CLI_CLIENT_ID: props.cliClientId,
-        COMMONFATE_API_URL: props.apiUrl,
+    this._lambda = new BaseLambdaFunction(this, "Function", {
+      functionProps: {
+        code,
+        // The frontend deployer has a 7 minute timeout
+        // internally, the deployer has a 5 minute retry backoff around the invalidation cloudfront method
+        // at worst execution would take around 5 mins 30s
+        timeout: Duration.seconds(60 * 7),
+        environment: {
+          CF_RELEASES_BUCKET: props.cfReleaseBucket,
+          CF_RELEASES_FRONTEND_ASSET_OBJECT_PREFIX:
+            props.cfReleaseBucketFrontendAssetObjectPrefix,
+          COMMONFATE_FRONTEND_BUCKET: props.frontendBucket.bucketName,
+          COMMONFATE_COGNITO_USER_POOL_ID: props.cognitoUserPoolId,
+          COMMONFATE_COGNITO_CLIENT_ID: props.cognitoClientId,
+          COMMONFATE_USER_POOL_DOMAIN: props.userPoolDomain,
+          COMMONFATE_FRONTEND_DOMAIN: props.frontendDomain,
+          COMMONFATE_CLOUDFRONT_DISTRIBUTION_ID: props.cloudfrontDistributionId,
+          COMMONFATE_CLI_CLIENT_ID: props.cliClientId,
+          COMMONFATE_API_URL: props.apiUrl,
+        },
+        runtime: lambda.Runtime.GO_1_X,
+        handler: "frontend-deployer",
       },
-      runtime: lambda.Runtime.GO_1_X,
-      handler: "frontend-deployer",
+      vpcConfig: props.vpcConfig
     });
 
     // Allow the deployer to deploy to the frontend bucket

--- a/deploy/infra/lib/constructs/production-frontend-deployer.ts
+++ b/deploy/infra/lib/constructs/production-frontend-deployer.ts
@@ -4,7 +4,7 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import { Construct } from "constructs";
 import * as path from "path";
-import {BaseLambdaFunction} from "../helpers/base-lambda";
+import { BaseLambdaFunction } from "../helpers/base-lambda";
 
 interface Props {
   cfReleaseBucket: string;
@@ -57,7 +57,7 @@ export class ProductionFrontendDeployer extends Construct {
         runtime: lambda.Runtime.GO_1_X,
         handler: "frontend-deployer",
       },
-      vpcConfig: props.vpcConfig
+      vpcConfig: props.vpcConfig,
     });
 
     // Allow the deployer to deploy to the frontend bucket

--- a/deploy/infra/lib/constructs/targetgroup-granter.ts
+++ b/deploy/infra/lib/constructs/targetgroup-granter.ts
@@ -7,8 +7,7 @@ import * as path from "path";
 import { EventBus } from "aws-cdk-lib/aws-events";
 import { grantAssumeHandlerRole } from "../helpers/permissions";
 import { Table } from "aws-cdk-lib/aws-dynamodb";
-import * as ec2 from 'aws-cdk-lib/aws-ec2'
-import {BaseLambdaFunction} from "../helpers/base-lambda";
+import { BaseLambdaFunction } from "../helpers/base-lambda";
 
 interface Props {
   eventBusSourceName: string;
@@ -32,7 +31,6 @@ export class TargetGroupGranter extends Construct {
         "targetgroup-granter.zip"
       )
     );
-
 
     this._lambda = new BaseLambdaFunction(this, "StepHandlerFunction", {
       functionProps: {

--- a/deploy/infra/lib/constructs/targetgroup-granter.ts
+++ b/deploy/infra/lib/constructs/targetgroup-granter.ts
@@ -7,13 +7,13 @@ import * as path from "path";
 import { EventBus } from "aws-cdk-lib/aws-events";
 import { grantAssumeHandlerRole } from "../helpers/permissions";
 import { Table } from "aws-cdk-lib/aws-dynamodb";
-import { BaseLambdaFunction } from "../helpers/base-lambda";
+import { BaseLambdaFunction, VpcConfig } from "../helpers/base-lambda";
 
 interface Props {
   eventBusSourceName: string;
   dynamoTable: Table;
   eventBus: EventBus;
-  vpcConfig: any;
+  vpcConfig: VpcConfig;
 }
 export class TargetGroupGranter extends Construct {
   private _stateMachine: sfn.StateMachine;

--- a/deploy/infra/lib/helpers/base-lambda.ts
+++ b/deploy/infra/lib/helpers/base-lambda.ts
@@ -1,0 +1,26 @@
+import * as cdk from "aws-cdk-lib";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import {PolicyStatement} from "aws-cdk-lib/aws-iam";
+
+export interface BaseLambdaFunProps {
+    functionProps: lambda.FunctionProps;
+    vpcConfig: any;
+}
+
+export class BaseLambdaFunction extends lambda.Function {
+    constructor(scope: any, id: string, props: BaseLambdaFunProps) {
+        super(scope, id, props.functionProps);
+        this.addToRolePolicy(new PolicyStatement({
+            actions: [
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:CreateNetworkInterface",
+                "ec2:DeleteNetworkInterface",
+                "ec2:DescribeInstances",
+                "ec2:AttachNetworkInterface"
+            ],
+            resources: ["*"],
+        }))
+        const cfnDist = this.node.defaultChild as cdk.CfnResource;
+        cfnDist.addPropertyOverride("VpcConfig", props.vpcConfig);
+    }
+}

--- a/deploy/infra/lib/helpers/base-lambda.ts
+++ b/deploy/infra/lib/helpers/base-lambda.ts
@@ -1,26 +1,28 @@
 import * as cdk from "aws-cdk-lib";
 import * as lambda from "aws-cdk-lib/aws-lambda";
-import {PolicyStatement} from "aws-cdk-lib/aws-iam";
+import { PolicyStatement } from "aws-cdk-lib/aws-iam";
 
 export interface BaseLambdaFunProps {
-    functionProps: lambda.FunctionProps;
-    vpcConfig: any;
+  functionProps: lambda.FunctionProps;
+  vpcConfig: any;
 }
 
 export class BaseLambdaFunction extends lambda.Function {
-    constructor(scope: any, id: string, props: BaseLambdaFunProps) {
-        super(scope, id, props.functionProps);
-        this.addToRolePolicy(new PolicyStatement({
-            actions: [
-                "ec2:DescribeNetworkInterfaces",
-                "ec2:CreateNetworkInterface",
-                "ec2:DeleteNetworkInterface",
-                "ec2:DescribeInstances",
-                "ec2:AttachNetworkInterface"
-            ],
-            resources: ["*"],
-        }))
-        const cfnDist = this.node.defaultChild as cdk.CfnResource;
-        cfnDist.addPropertyOverride("VpcConfig", props.vpcConfig);
-    }
+  constructor(scope: any, id: string, props: BaseLambdaFunProps) {
+    super(scope, id, props.functionProps);
+    this.addToRolePolicy(
+      new PolicyStatement({
+        actions: [
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:CreateNetworkInterface",
+          "ec2:DeleteNetworkInterface",
+          "ec2:DescribeInstances",
+          "ec2:AttachNetworkInterface",
+        ],
+        resources: ["*"],
+      })
+    );
+    const cfnDist = this.node.defaultChild as cdk.CfnResource;
+    cfnDist.addPropertyOverride("VpcConfig", props.vpcConfig);
+  }
 }

--- a/deploy/infra/lib/helpers/base-lambda.ts
+++ b/deploy/infra/lib/helpers/base-lambda.ts
@@ -2,9 +2,17 @@ import * as cdk from "aws-cdk-lib";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { PolicyStatement } from "aws-cdk-lib/aws-iam";
 
+export type VpcConfig = {
+  // The intended data type for the SubnetIds and SecurityGroupIds fields is a list of strings.
+  // However, in the production stack, the type of these fields is ICfnRuleConditionExpression, while in the development stack, it is string[].
+  // To accommodate this difference, we are currently using 'any' data type to represent these fields.
+  subnetIds: any;
+  securityGroupIds: any;
+};
+
 export interface BaseLambdaFunProps {
   functionProps: lambda.FunctionProps;
-  vpcConfig: any;
+  vpcConfig: VpcConfig;
 }
 
 export class BaseLambdaFunction extends lambda.Function {

--- a/pkg/deploy/cdk.go
+++ b/pkg/deploy/cdk.go
@@ -94,6 +94,12 @@ func (c Config) CDKContextArgs() []string {
 	if c.Deployment.Parameters.IDPSyncTimeoutSeconds != "" {
 		args = append(args, "-c", fmt.Sprintf("idpSyncTimeoutSeconds=%s", string(c.Deployment.Parameters.IDPSyncTimeoutSeconds)))
 	}
+	if len(c.Deployment.Parameters.LambdaSubnetIds) != 0 {
+		args = append(args, "-c", fmt.Sprintf("subnetIds=%s", strings.Join(c.Deployment.Parameters.LambdaSubnetIds, ",")))
+	}
+	if len(c.Deployment.Parameters.LambdaSecurityGroups) != 0 {
+		args = append(args, "-c", fmt.Sprintf("securityGroups=%s", strings.Join(c.Deployment.Parameters.LambdaSecurityGroups, ",")))
+	}
 
 	if c.Deployment.Parameters.AutoApprovalLambdaARN != "" {
 		args = append(args, "-c", fmt.Sprintf("autoApprovalLambdaARN=%s", string(c.Deployment.Parameters.AutoApprovalLambdaARN)))

--- a/pkg/deploy/config.go
+++ b/pkg/deploy/config.go
@@ -190,7 +190,8 @@ type Parameters struct {
 	IDPSyncSchedule                 string         `yaml:"IDPSyncSchedule,omitempty"`
 	IDPSyncMemory                   string         `yaml:"IDPSyncMemory,omitempty"`
 	AutoApprovalLambdaARN           string         `yaml:"AutoApprovalLambdaARN,omitempty"`
-	LambdaVpcId                     string         `yaml:"LambdaVpcId,omitempty"`
+	LambdaSubnetIds                 []string       `yaml:"LambdaSubnetIds,omitempty"`
+	LambdaSecurityGroups            []string       `yaml:"LambdaSecurityGroups,omitempty"`
 }
 
 // UnmarshalFeatureMap parses the JSON configuration data and returns
@@ -545,7 +546,19 @@ func (c *Config) CfnParams() ([]types.Parameter, error) {
 			ParameterValue: &p.IDPSyncTimeoutSeconds,
 		})
 	}
+	if len(c.Deployment.Parameters.LambdaSubnetIds) != 0 {
+		res = append(res, types.Parameter{
+			ParameterKey:   aws.String("LambdaSubnetIds"),
+			ParameterValue: aws.String(strings.Join(p.LambdaSubnetIds, ",")),
+		})
+	}
 
+	if len(c.Deployment.Parameters.LambdaSecurityGroups) != 0 {
+		res = append(res, types.Parameter{
+			ParameterKey:   aws.String("LambdaSecurityGroups"),
+			ParameterValue: aws.String(strings.Join(p.LambdaSecurityGroups, ",")),
+		})
+	}
 	return res, nil
 }
 

--- a/pkg/deploy/config.go
+++ b/pkg/deploy/config.go
@@ -190,6 +190,7 @@ type Parameters struct {
 	IDPSyncSchedule                 string         `yaml:"IDPSyncSchedule,omitempty"`
 	IDPSyncMemory                   string         `yaml:"IDPSyncMemory,omitempty"`
 	AutoApprovalLambdaARN           string         `yaml:"AutoApprovalLambdaARN,omitempty"`
+	LambdaVpcId                     string         `yaml:"LambdaVpcId,omitempty"`
 }
 
 // UnmarshalFeatureMap parses the JSON configuration data and returns


### PR DESCRIPTION
### What changed?
This PR introduce two new settings that users can provide `LambdaSubnetIds` and `LambdaSecurityGroups`. Only if two of them are provided changes take place.
 `LambdaSubnetIds` - list of subnets ids that are used by all lambdas
`LambdaSecurityGroups` - list of security groups that are used by all lambdas

### Why?
This is necessary due to security requirements on the IP list from where our resources(such as Okta groups) can be modified/accessed


### How did you test it?
1. Development stack was deployed to devel environment by running "mage deploy:dev"
2. Production stack was synthesized by running `mage release:publishCloudFormation  bucket-name hash`

### Potential risks
No

### Is patch release candidate?
Yes

### Link to relevant docs PRs
https://github.com/common-fate/glide/issues/623