### PR TITLE
Fix autoapproval functionality and vpc config

### DIFF
--- a/deploy/infra/bin/common-fate.ts
+++ b/deploy/infra/bin/common-fate.ts
@@ -108,7 +108,7 @@ if (stackTarget === "dev") {
     idpSyncMemory: idpSyncMemory || 128,
     idpSyncSchedule: idpSyncSchedule || "rate(5 minutes)",
     idpSyncTimeoutSeconds: idpSyncTimeoutSeconds || 30,
-    autoApprovalLambdaARN: autoApprovalLambdaARN,
+    autoApprovalLambdaARN: autoApprovalLambdaARN || "",
     subnetIds: subnetIds || "",
     securityGroups: securityGroups || "",
   });

--- a/deploy/infra/lib/common-fate-stack-dev.ts
+++ b/deploy/infra/lib/common-fate-stack-dev.ts
@@ -87,8 +87,8 @@ export class CommonFateStackDev extends cdk.Stack {
     );
 
     const vpcConfig: VpcConfig = {
-      subnetIds: cdk.Fn.conditionIf(attachLambdaToVpcCondition.logicalId, props.subnetIds.split(","), []),
-      securityGroupIds: cdk.Fn.conditionIf(attachLambdaToVpcCondition.logicalId, props.securityGroups.split(","), []),
+      SubnetIds: cdk.Fn.conditionIf(attachLambdaToVpcCondition.logicalId, props.subnetIds.split(","), []),
+      SecurityGroupIds: cdk.Fn.conditionIf(attachLambdaToVpcCondition.logicalId, props.securityGroups.split(","), []),
     }
 
 

--- a/deploy/infra/lib/common-fate-stack-prod.ts
+++ b/deploy/infra/lib/common-fate-stack-prod.ts
@@ -140,10 +140,6 @@ export class CommonFateStackProd extends cdk.Stack {
       }
     );
 
-    //     IDPSyncTimeoutSeconds
-    // IDPSyncSchedule
-    // IDPSyncMemory
-
     const idpSyncTimeoutSeconds = new CfnParameter(
       this,
       "IDPSyncTimeoutSeconds",
@@ -247,8 +243,8 @@ export class CommonFateStackProd extends cdk.Stack {
     );
 
     const vpcConfig: VpcConfig = {
-      subnetIds: cdk.Fn.conditionIf(attachLambdaToVpcCondition.logicalId, subnetIds.valueAsString.split(","), []),
-      securityGroupIds: cdk.Fn.conditionIf(attachLambdaToVpcCondition.logicalId, securityGroups.valueAsString.split(","), [])
+      SubnetIds: cdk.Fn.conditionIf(attachLambdaToVpcCondition.logicalId, subnetIds.valueAsString.split(","), []),
+      SecurityGroupIds: cdk.Fn.conditionIf(attachLambdaToVpcCondition.logicalId, securityGroups.valueAsString.split(","), [])
     }
 
     const appName = this.stackName + suffix.valueAsString;

--- a/deploy/infra/lib/helpers/base-lambda.ts
+++ b/deploy/infra/lib/helpers/base-lambda.ts
@@ -6,8 +6,8 @@ export type VpcConfig = {
   // The intended data type for the SubnetIds and SecurityGroupIds fields is a list of strings.
   // However, in the production stack, the type of these fields is ICfnRuleConditionExpression, while in the development stack, it is string[].
   // To accommodate this difference, we are currently using 'any' data type to represent these fields.
-  subnetIds: any;
-  securityGroupIds: any;
+  SubnetIds: any;
+  SecurityGroupIds: any;
 };
 
 export interface BaseLambdaFunProps {

--- a/pkg/service/accesssvc/create.go
+++ b/pkg/service/accesssvc/create.go
@@ -211,7 +211,7 @@ func (s *Service) createRequest(ctx context.Context, in createRequestOpts) (Crea
 	arn := os.Getenv("COMMONFATE_AUTO_APPROVAL_LAMBDA_ARN")
 	var autoapproved bool
 	if arn != "" {
-		autoapproved, err = autoapproval.Service{}.Autoapprove(in.User, in.Rule, "123")
+		autoapproved, err = autoapproval.Service{}.Autoapprove(in.User, in.Rule, arn)
 		if err != nil {
 			log.Errorw("error happened when calling auto-approval lambda", "err", err)
 		}


### PR DESCRIPTION
### What changed?
This is the follow up PR to https://github.com/common-fate/glide/pull/634 and https://github.com/common-fate/glide/pull/635

### Why?
1. It fixes issues that introduced here - https://github.com/common-fate/glide/pull/634/files#diff-e6133f6c0ef497adc2b8f4726520a08b12f07be2a999f850f8f8f3b83df4c676R214. It should be lambda arn instead of `123`.
2. If fixes a bug introduced in this commit - https://github.com/common-fate/glide/pull/635/commits/d5059c9a41d025a7724c92311d5a410f5226ae61. vpcConfig fields should start from capital letter otherwise error is thrown during deployment
```
extraneous key is not permitted
```

### How did you test it?
1. Development stack was deployed to devel environment by running "mage deploy:dev"
3. Production stack was synthesized by running mage release:publishCloudFormation  bucket-name hash

### Potential risks
Changes are scope to CDK logic so potential bugs should be isolated to deployment stage.

### Is patch release candidate?

### Link to relevant docs PRs
