### PR TITLE
Fix cloudformation vpc parameter names

### DIFF
--- a/pkg/deploy/config.go
+++ b/pkg/deploy/config.go
@@ -548,14 +548,14 @@ func (c *Config) CfnParams() ([]types.Parameter, error) {
 	}
 	if len(c.Deployment.Parameters.LambdaSubnetIds) != 0 {
 		res = append(res, types.Parameter{
-			ParameterKey:   aws.String("LambdaSubnetIds"),
+			ParameterKey:   aws.String("SubnetIds"),
 			ParameterValue: aws.String(strings.Join(p.LambdaSubnetIds, ",")),
 		})
 	}
 
 	if len(c.Deployment.Parameters.LambdaSecurityGroups) != 0 {
 		res = append(res, types.Parameter{
-			ParameterKey:   aws.String("LambdaSecurityGroups"),
+			ParameterKey:   aws.String("SecurityGroups"),
 			ParameterValue: aws.String(strings.Join(p.LambdaSecurityGroups, ",")),
 		})
 	}

--- a/pkg/deploy/config.go
+++ b/pkg/deploy/config.go
@@ -559,6 +559,12 @@ func (c *Config) CfnParams() ([]types.Parameter, error) {
 			ParameterValue: aws.String(strings.Join(p.LambdaSecurityGroups, ",")),
 		})
 	}
+	if len(c.Deployment.Parameters.AutoApprovalLambdaARN) != 0 {
+		res = append(res, types.Parameter{
+			ParameterKey:   aws.String("AutoApprovalLambdaARN"),
+			ParameterValue: aws.String(p.AutoApprovalLambdaARN),
+		})
+	}
 	return res, nil
 }
 


### PR DESCRIPTION
### What changed?
This PR changes parameters that cloudformation is run with. 

### Why?
We need to match variables in gdeploy config and in cloudformation. Otherwise you get error like this:
```
[✘] failed to load config with error: yaml: unmarshal errors:
  line 35: field SubnetIds not found in type deploy.Parameters
  line 36: field SecurityGroups not found in type deploy.Parameters
```

### How did you test it?
By building gdeploy from the branch and later running `gdeploy update` against https://releases.commonfate.io/gdeploy/v0.15.13/gdeploy_0.15.13_darwin_x86_64.tar.gz

### Potential risks
Changes only touch deployment phase, so all bugs should be scoped to this.

### Is patch release candidate?


### Link to relevant docs PRs
https://github.com/common-fate/glide/pull/635